### PR TITLE
Senders, Support Mailgun

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With Keila you can easily send out newsletter campaigns and create sign-up
 forms.
 
 For smaller newsletters, you can use your own email inbox to send out campaigns.
-For larger newsletter projects, AWS SES and Sendgrid are supported in addition
+For larger newsletter projects, AWS SES, Sendgrid and Mailgun are supported in addition
 to SMTP.
 
 ![Screenshot of the Keila form editor showing color modification and custom texts](.github/assets/screenshot-form.png)
@@ -19,7 +19,7 @@ to SMTP.
 Keila is still in development but you can already give it a try.
 To run it, follow these steps:
 
-* Clone the repository: 
+* Clone the repository:
   `git clone https://github.com/pentacent/keila.git`
 * [Install Elixir](https://elixir-lang.org/install.html)
 * Install dependencies with `mix deps.get`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With Keila you can easily send out newsletter campaigns and create sign-up
 forms.
 
 For smaller newsletters, you can use your own email inbox to send out campaigns.
-For larger newsletter projects, AWS SES, Sendgrid and Mailgun are supported in addition
+For larger newsletter projects, AWS SES, Sendgrid, and Mailgun are supported in addition
 to SMTP.
 
 ![Screenshot of the Keila form editor showing color modification and custom texts](.github/assets/screenshot-form.png)

--- a/lib/keila_web/templates/sender/_mailgun_config.html.eex
+++ b/lib/keila_web/templates/sender/_mailgun_config.html.eex
@@ -1,0 +1,12 @@
+<div class="flex flex-col">
+    <%= label(@form, :mailgun_domain, "Domain") %>
+    <%= with_validation(@form, :mailgun_domain) do %>
+        <%= text_input(@form, :mailgun_domain, class: "text-black") %>
+    <% end %>
+</div>
+<div class="flex flex-col">
+    <%= label(@form, :mailgun_api_key, "API Key") %>
+    <%= with_validation(@form, :mailgun_api_key) do %>
+        <%= password_input(@form, :mailgun_api_key, class: "text-black") %>
+    <% end %>
+</div>

--- a/lib/keila_web/templates/sender/edit.html.leex
+++ b/lib/keila_web/templates/sender/edit.html.leex
@@ -48,13 +48,16 @@
 
                     <%= inputs_for f, :config, fn fc -> %>
                         <div x-data="{ tab: $el.querySelector('#sender_config_type').value }" class="tabs">
-                            <%= select(fc, :type, ["smtp", "sendgrid", "ses"], x_model: "tab", x_show: "false") %>
+                            <%= select(fc, :type, ["smtp", "sendgrid", "mailgun", "ses"], x_model: "tab", x_show: "false") %>
 
                             <a href="#" class="tab-label" :class="{ 'active': tab === 'smtp' }" @click.prevent="tab = 'smtp'">
                                 SMTP
                             </a>
                             <a href="#" class="tab-label" :class="{ 'active': tab === 'sendgrid' }" @click.prevent="tab = 'sendgrid'">
                                 Sendgrid
+                            </a>
+                            <a href="#" class="tab-label" :class="{ 'active': tab === 'mailgun' }" @click.prevent="tab = 'mailgun'">
+                                Mailgun
                             </a>
                             <a href="#" class="tab-label" :class="{ 'active': tab === 'ses' }" @click.prevent="tab = 'ses'">
                                 SES
@@ -68,6 +71,11 @@
                             <template x-if="tab === 'sendgrid'">
                                 <div class="tab-content">
                                     <%= render("_sendgrid_config.html", form: fc) %>
+                                </div>
+                            </template>
+                            <template x-if="tab === 'mailgun'">
+                                <div class="tab-content">
+                                    <%= render("_mailgun_config.html", form: fc) %>
                                 </div>
                             </template>
                             <template x-if="tab === 'ses'">


### PR DESCRIPTION
This patch adds support for Mailgun.
Mailgun is supported out of the box by Swoosh (https://github.com/swoosh/swoosh#adapters).

I understand if we don't want to support all adapters supported by swoosh.
If that is the eventual goal we might want to invest some time to make it easier to support a larger amount of adapters by drying up the custom logic around supporting different adapters in the UI and backend.

Closes https://github.com/pentacent/keila/issues/3