### PR TITLE
CI, Only Build and Push Container on Main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-      branches:
+    branches:
       - main
 
 jobs:
@@ -52,6 +52,7 @@ jobs:
         run: mix test
   build:
     name: Build and push Docker image
+    if: github.ref == 'refs/heads/main'
     needs:
       - test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This patch adds a conditional to the `Build and push Docker image` job so that this only runs on the `main` branch.
The indentation of the top-level `on:` option has also been fixed.

**Potential Followups**

We might want to look into generating docker version tags dynamically since currently, we push all merged changes to the same `0.1` tag.
If we introduce dynamically generated versions we technically could even use that to tag PRs if we really want that.