### PR TITLE
Refactor, Generalize SenderAdapter Code

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,14 @@ config :keila, Keila.Id,
   salt: "bF4QzDjqV",
   min_len: 8
 
+config :keila, Keila.Mailings.SenderAdapters,
+  adapters: [
+    Keila.Mailings.SenderAdapters.SMTP,
+    Keila.Mailings.SenderAdapters.Sendgrid,
+    Keila.Mailings.SenderAdapters.SES,
+    Keila.Mailings.SenderAdapters.Mailgun
+  ]
+
 # Staging configuration for hCaptcha
 config :keila, KeilaWeb.Hcaptcha,
   secret_key: "0x0000000000000000000000000000000000000000",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -152,7 +152,8 @@ if config_env() == :prod do
 
   # Deployment
   config :keila,
-    registration_disabled: System.get_env("DISABLE_REGISTRATION") not in [nil, 0, "", "false", "FALSE"]
+    registration_disabled:
+      System.get_env("DISABLE_REGISTRATION") not in [nil, 0, "", "false", "FALSE"]
 end
 
 if config_env() == :test do

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,3 +30,10 @@ config :argon2_elixir, t_cost: 1, m_cost: 8
 
 # Disable Oban Queues
 config :keila, Oban, queues: false, plugins: false
+
+# Only use test and smtp Sender Adapters
+config :keila, Keila.Mailings.SenderAdapters,
+  adapters: [
+    Keila.Mailings.SenderAdapters.SMTP,
+    Keila.TestSenderAdapter
+  ]

--- a/lib/keila/mailings/schemas/sender_config.ex
+++ b/lib/keila/mailings/schemas/sender_config.ex
@@ -1,5 +1,6 @@
 defmodule Keila.Mailings.Sender.Config do
   use Ecto.Schema
+  alias Keila.Mailings.SenderAdapters
   alias Ecto.Changeset
   import Ecto.Changeset
 
@@ -8,68 +9,24 @@ defmodule Keila.Mailings.Sender.Config do
   embedded_schema do
     field :type, :string
 
-    field :smtp_relay, :string
-    field :smtp_username, :string
-    field :smtp_password, :string
-    field :smtp_tls, :boolean
-    field :smtp_port, :integer
-
-    field :ses_region, :string
-    field :ses_access_key, :string
-    field :ses_secret, :string
-
-    field :sendgrid_api_key, :string
-
-    field :mailgun_api_key, :string
-    field :mailgun_domain, :string
+    SenderAdapters.schema_fields() |> Enum.each(fn {name, type} -> field(name, type) end)
   end
 
   @spec changeset(Ecto.Changeset.data(), map()) :: Ecto.Changeset.t(t())
   def changeset(struct \\ %__MODULE__{}, params) do
     struct
     |> cast(params, [:type])
-    |> validate_inclusion(:type, ["smtp", "ses", "sendgrid", "mailgun"])
-    |> maybe_cast_smtp(params)
-    |> maybe_cast_ses(params)
-    |> maybe_cast_sendgrid(params)
-    |> maybe_cast_mailgun(params)
+    |> validate_inclusion(:type, SenderAdapters.adapter_names())
+    |> cast_sender_adapter(params)
   end
 
-  defp maybe_cast_smtp(changeset, params) do
-    if Changeset.get_field(changeset, :type) == "smtp" do
-      changeset
-      |> cast(params, [:smtp_relay, :smtp_username, :smtp_password, :smtp_tls, :smtp_port])
-      |> validate_required([:smtp_relay, :smtp_username, :smtp_password])
-    else
-      changeset
-    end
-  end
+  defp cast_sender_adapter(changeset, params) do
+    adapter =
+      Changeset.get_field(changeset, :type)
+      |> SenderAdapters.get_adapter()
 
-  defp maybe_cast_ses(changeset, params) do
-    if Changeset.get_field(changeset, :type) == "ses" do
-      changeset
-      |> cast(params, [:ses_region, :ses_access_key, :ses_secret])
-      |> validate_required([:ses_region, :ses_access_key, :ses_secret])
-    else
-      changeset
-    end
-  end
-
-  defp maybe_cast_sendgrid(changeset, params) do
-    if Changeset.get_field(changeset, :type) == "sendgrid" do
-      changeset
-      |> cast(params, [:sendgrid_api_key])
-      |> validate_required([:sendgrid_api_key])
-    else
-      changeset
-    end
-  end
-
-  defp maybe_cast_mailgun(changeset, params) do
-    if Changeset.get_field(changeset, :type) == "mailgun" do
-      changeset
-      |> cast(params, [:mailgun_api_key, :mailgun_domain])
-      |> validate_required([:mailgun_api_key, :mailgun_domain])
+    if adapter do
+      adapter.changeset(changeset, params)
     else
       changeset
     end
@@ -80,57 +37,9 @@ defmodule Keila.Mailings.Sender.Config do
   """
   @spec to_swoosh_config(t()) :: Keyword.t()
   def to_swoosh_config(struct = %__MODULE__{}) do
-    case struct.type do
-      "smtp" -> to_smtp_config(struct)
-      "ses" -> to_ses_config(struct)
-      "sendgrid" -> to_sendgrid_config(struct)
-      "mailgun" -> to_mailgun_config(struct)
-      _ -> maybe_to_standard_config(struct)
-    end
+    adapter = SenderAdapters.get_adapter(struct.type)
+
+    adapter.to_swoosh_config(struct)
     |> Enum.filter(fn {_, v} -> not is_nil(v) end)
-  end
-
-  defp to_smtp_config(struct) do
-    [
-      adapter: Swoosh.Adapters.SMTP,
-      relay: struct.smtp_relay,
-      username: struct.smtp_username,
-      password: struct.smtp_password,
-      tls: if(struct.smtp_tls, do: :always),
-      auth: :always,
-      port: struct.smtp_port
-    ]
-  end
-
-  defp to_ses_config(struct) do
-    [
-      adapter: Swoosh.Adapters.SES,
-      region: struct.ses_region,
-      access_key: struct.ses_access_key,
-      secret: struct.ses_secret
-    ]
-  end
-
-  defp to_sendgrid_config(struct) do
-    [
-      adapter: Swoosh.Adapters.Sendgrid,
-      api_key: struct.sendgrid_api_key
-    ]
-  end
-
-  defp to_mailgun_config(struct) do
-    [
-      adapter: Swoosh.Adapters.Mailgun,
-      api_key: struct.mailgun_api_key,
-      domain: struct.mailgun_domain
-    ]
-  end
-
-  defp maybe_to_standard_config(_struct) do
-    if Mix.env() in [:test, :dev] do
-      []
-    else
-      raise "Missing configuration"
-    end
   end
 end

--- a/lib/keila/mailings/sender_adapters.ex
+++ b/lib/keila/mailings/sender_adapters.ex
@@ -1,0 +1,39 @@
+defmodule Keila.Mailings.SenderAdapters do
+  @moduledoc """
+  Module for retrieving configured sender adapters and associated data.
+  """
+
+  @doc """
+  Returns all configured sender adapter modules.
+  """
+  @spec adapters() :: list(Keila.Mailings.SenderAdapters.Adapter.t())
+  def adapters do
+    Application.get_env(:keila, __MODULE__, [])
+    |> Keyword.get(:adapters)
+  end
+
+  @doc """
+  Returns the names of all configured sender adapters.
+  """
+  @spec adapter_names() :: list(String.t())
+  def adapter_names do
+    Enum.map(adapters(), fn a -> a.name end)
+  end
+
+  @doc """
+  Returns the configured sender adapter with the given `name`
+  """
+  @spec get_adapter(String.t()) :: Keila.Mailings.SenderAdapters.Adapter.t()
+  def get_adapter(name) do
+    Enum.find(adapters(), fn a -> a.name == name end)
+  end
+
+  @doc """
+  Returns a combined list of `schema_fields` from all configured modules.
+  """
+  @spec schema_fields() :: keyword(atom())
+  def schema_fields do
+    Enum.map(adapters(), fn a -> a.schema_fields() end)
+    |> List.flatten()
+  end
+end

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -1,0 +1,76 @@
+defmodule Keila.Mailings.SenderAdapters.Adapter do
+  @moduledoc """
+  Defines a sender adapter.
+
+  Sender adapters are used by Keila to support sending campaings through various services.
+
+  `schema_fields/0` define configuration fields which will dynamically be added to the `Keila.Mailing.Sender.Config` schema.
+
+  `changeset/2` will be used to build a changeset for the configuration fields before storing them in a `Keila.Mailing.Sender.Config` schema.
+
+  `to_swoosh_config/1` allows to retrieve configuration fields from the `Keila.Mailings.Sender.Config` and build a config that will be passed to `Swoosh`.
+
+  ## Example
+      defmodule Sendgrid do
+        use Keila.Mailings.SenderAdapters.Adapter
+
+        @impl true
+        def name, do: "sendgrid"
+
+        @impl true
+        def schema_fields do
+          [
+            sendgrid_api_key: :string
+          ]
+        end
+
+        @impl true
+        def changeset(changeset, params) do
+          changeset
+          |> cast(params, [:sendgrid_api_key])
+          |> validate_required([:sendgrid_api_key])
+        end
+
+        @impl true
+        def to_swoosh_config(struct) do
+          [
+            adapter: Swoosh.Adapters.Sendgrid,
+            api_key: struct.sendgrid_api_key
+          ]
+        end
+      end
+
+  ## Configuration
+      config :keila, Keila.Mailings.SenderAdapters, adapters: [NewSenderAdapter]
+  """
+
+  defmacro __using__(_options) do
+    quote do
+      @behaviour unquote(__MODULE__)
+      import Ecto.Changeset
+      alias unquote(__MODULE__)
+    end
+  end
+
+  @type t :: module
+
+  @doc """
+  Returns the name of the sender adapter.
+  """
+  @callback name() :: String.t()
+
+  @doc """
+  Returns a list of exto schema fields that the adapter requires.
+  """
+  @callback schema_fields() :: keyword(atom())
+
+  @doc """
+  Builds a changeset for the sender adapter configuration.
+  """
+  @callback changeset(Ecto.Changeset.t(), %{optional(String.t()) => term()} | %{optional(atom()) => term()}) :: Ecto.Changeset.t()
+
+  @doc """
+  Builds a swoosh config from the passed sender adapter configuration.
+  """
+  @callback to_swoosh_config(struct()) :: keyword()
+end

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -4,7 +4,7 @@ defmodule Keila.Mailings.SenderAdapters.Adapter do
 
   Sender adapters are used by Keila to support sending campaings through various services.
 
-  `schema_fields/0` define configuration fields which will dynamically be added to the `Keila.Mailing.Sender.Config` schema.
+  `schema_fields/0` defines configuration fields which will dynamically be added to the `Keila.Mailings.Sender.Config` schema.
 
   `changeset/2` will be used to build a changeset for the configuration fields before storing them in a `Keila.Mailing.Sender.Config` schema.
 

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -6,7 +6,8 @@ defmodule Keila.Mailings.SenderAdapters.Adapter do
 
   `schema_fields/0` defines configuration fields which will dynamically be added to the `Keila.Mailings.Sender.Config` schema.
 
-  `changeset/2` will be used to build a changeset for the configuration fields before storing them in a `Keila.Mailing.Sender.Config` schema.
+  `changeset/2` will be used to build a changeset for the configuration fields
+  before storing them in a `Keila.Mailings.Sender.Config` schema.
 
   `to_swoosh_config/1` allows to retrieve configuration fields from the `Keila.Mailings.Sender.Config` and build a config that will be passed to `Swoosh`.
 

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -62,7 +62,7 @@ defmodule Keila.Mailings.SenderAdapters.Adapter do
   @callback name() :: String.t()
 
   @doc """
-  Returns a list of exto schema fields that the adapter requires.
+  Returns a list of Ecto schema fields required by the adapter.
   """
   @callback schema_fields() :: keyword(atom())
 

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -69,7 +69,10 @@ defmodule Keila.Mailings.SenderAdapters.Adapter do
   @doc """
   Builds a changeset for the sender adapter configuration.
   """
-  @callback changeset(Ecto.Changeset.t(), %{optional(String.t()) => term()} | %{optional(atom()) => term()}) :: Ecto.Changeset.t()
+  @callback changeset(
+              Ecto.Changeset.t(),
+              %{optional(String.t()) => term()} | %{optional(atom()) => term()}
+            ) :: Ecto.Changeset.t()
 
   @doc """
   Builds a swoosh config from the passed sender adapter configuration.

--- a/lib/keila/mailings/sender_adapters/adapter.ex
+++ b/lib/keila/mailings/sender_adapters/adapter.ex
@@ -9,7 +9,8 @@ defmodule Keila.Mailings.SenderAdapters.Adapter do
   `changeset/2` will be used to build a changeset for the configuration fields
   before storing them in a `Keila.Mailings.Sender.Config` schema.
 
-  `to_swoosh_config/1` allows to retrieve configuration fields from the `Keila.Mailings.Sender.Config` and build a config that will be passed to `Swoosh`.
+  `to_swoosh_config/1` retrieves configuration fields from
+   `Keila.Mailings.Sender.Config` and builds the config that is passed to `Swoosh`.
 
   ## Example
       defmodule Sendgrid do

--- a/lib/keila/mailings/sender_adapters/mailgun.ex
+++ b/lib/keila/mailings/sender_adapters/mailgun.ex
@@ -1,0 +1,30 @@
+defmodule Keila.Mailings.SenderAdapters.Mailgun do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "mailgun"
+
+  @impl true
+  def schema_fields do
+    [
+      mailgun_api_key: :string,
+      mailgun_domain: :string
+    ]
+  end
+
+  @impl true
+  def changeset(changeset, params) do
+    changeset
+    |> cast(params, [:mailgun_api_key, :mailgun_domain])
+    |> validate_required([:mailgun_api_key, :mailgun_domain])
+  end
+
+  @impl true
+  def to_swoosh_config(struct) do
+    [
+      adapter: Swoosh.Adapters.Mailgun,
+      api_key: struct.mailgun_api_key,
+      domain: struct.mailgun_domain
+    ]
+  end
+end

--- a/lib/keila/mailings/sender_adapters/sendgrid.ex
+++ b/lib/keila/mailings/sender_adapters/sendgrid.ex
@@ -1,0 +1,28 @@
+defmodule Keila.Mailings.SenderAdapters.Sendgrid do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "sendgrid"
+
+  @impl true
+  def schema_fields do
+    [
+      sendgrid_api_key: :string
+    ]
+  end
+
+  @impl true
+  def changeset(changeset, params) do
+    changeset
+    |> cast(params, [:sendgrid_api_key])
+    |> validate_required([:sendgrid_api_key])
+  end
+
+  @impl true
+  def to_swoosh_config(struct) do
+    [
+      adapter: Swoosh.Adapters.Sendgrid,
+      api_key: struct.sendgrid_api_key
+    ]
+  end
+end

--- a/lib/keila/mailings/sender_adapters/ses.ex
+++ b/lib/keila/mailings/sender_adapters/ses.ex
@@ -1,0 +1,32 @@
+defmodule Keila.Mailings.SenderAdapters.SES do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "ses"
+
+  @impl true
+  def schema_fields do
+    [
+      ses_region: :string,
+      ses_access_key: :string,
+      ses_secret: :string
+    ]
+  end
+
+  @impl true
+  def changeset(changeset, params) do
+    changeset
+    |> cast(params, [:ses_region, :ses_access_key, :ses_secret])
+    |> validate_required([:ses_region, :ses_access_key, :ses_secret])
+  end
+
+  @impl true
+  def to_swoosh_config(struct) do
+    [
+      adapter: Swoosh.Adapters.SES,
+      region: struct.ses_region,
+      access_key: struct.ses_access_key,
+      secret: struct.ses_secret
+    ]
+  end
+end

--- a/lib/keila/mailings/sender_adapters/smtp.ex
+++ b/lib/keila/mailings/sender_adapters/smtp.ex
@@ -1,0 +1,37 @@
+defmodule Keila.Mailings.SenderAdapters.SMTP do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "smtp"
+
+  @impl true
+  def schema_fields do
+    [
+      smtp_relay: :string,
+      smtp_username: :string,
+      smtp_password: :string,
+      smtp_tls: :boolean,
+      smtp_port: :integer
+    ]
+  end
+
+  @impl true
+  def changeset(changeset, params) do
+    changeset
+    |> cast(params, [:smtp_relay, :smtp_username, :smtp_password, :smtp_tls, :smtp_port])
+    |> validate_required([:smtp_relay, :smtp_username, :smtp_password])
+  end
+
+  @impl true
+  def to_swoosh_config(struct) do
+    [
+      adapter: Swoosh.Adapters.SMTP,
+      relay: struct.smtp_relay,
+      username: struct.smtp_username,
+      password: struct.smtp_password,
+      tls: if(struct.smtp_tls, do: :always),
+      auth: :always,
+      port: struct.smtp_port
+    ]
+  end
+end

--- a/lib/keila_web/templates/sender/edit.html.leex
+++ b/lib/keila_web/templates/sender/edit.html.leex
@@ -48,41 +48,21 @@
 
                     <%= inputs_for f, :config, fn fc -> %>
                         <div x-data="{ tab: $el.querySelector('#sender_config_type').value }" class="tabs">
-                            <%= select(fc, :type, ["smtp", "sendgrid", "mailgun", "ses"], x_model: "tab", x_show: "false") %>
+                            <%= select(fc, :type, sender_adapters(), x_model: "tab", x_show: "false") %>
 
-                            <a href="#" class="tab-label" :class="{ 'active': tab === 'smtp' }" @click.prevent="tab = 'smtp'">
-                                SMTP
-                            </a>
-                            <a href="#" class="tab-label" :class="{ 'active': tab === 'sendgrid' }" @click.prevent="tab = 'sendgrid'">
-                                Sendgrid
-                            </a>
-                            <a href="#" class="tab-label" :class="{ 'active': tab === 'mailgun' }" @click.prevent="tab = 'mailgun'">
-                                Mailgun
-                            </a>
-                            <a href="#" class="tab-label" :class="{ 'active': tab === 'ses' }" @click.prevent="tab = 'ses'">
-                                SES
-                            </a>
+                            <%= for adapter <- sender_adapters() do %>
+                              <a href="#" class="tab-label" :class="{ 'active': tab === '<%= adapter %>' }" @click.prevent="tab = '<%= adapter %>'">
+                                <%= sender_adapter_name(adapter) %>
+                              </a>
+                            <% end %>
 
-                            <template x-if="tab === 'smtp'">
+                            <%= for adapter <- sender_adapters() do %>
+                              <template x-if="tab === '<%= adapter %>'">
                                 <div class="tab-content">
-                                    <%= render("_smtp_config.html", form: fc) %>
+                                  <%= render_sender_adapter_form(fc, adapter) %>
                                 </div>
-                            </template>
-                            <template x-if="tab === 'sendgrid'">
-                                <div class="tab-content">
-                                    <%= render("_sendgrid_config.html", form: fc) %>
-                                </div>
-                            </template>
-                            <template x-if="tab === 'mailgun'">
-                                <div class="tab-content">
-                                    <%= render("_mailgun_config.html", form: fc) %>
-                                </div>
-                            </template>
-                            <template x-if="tab === 'ses'">
-                                <div class="tab-content">
-                                    <%= render("_ses_config.html", form: fc) %>
-                                </div>
-                            </template>
+                              </template>
+                            <% end %>
                         </div>
 
                     <% end %>

--- a/lib/keila_web/views/sender_view.ex
+++ b/lib/keila_web/views/sender_view.ex
@@ -9,6 +9,7 @@ defmodule KeilaWeb.SenderView do
   def sender_adapter_name("ses"), do: "SES"
   def sender_adapter_name("sendgrid"), do: "Sendgrid"
   def sender_adapter_name("mailgun"), do: "Mailgun"
+
   if Mix.env() == :test do
     def sender_adapter_name("test"), do: "Test"
   end
@@ -28,6 +29,7 @@ defmodule KeilaWeb.SenderView do
   def render_sender_adapter_form(form, "mailgun") do
     render("_mailgun_config.html", form: form)
   end
+
   if Mix.env() == :test do
     def render_sender_adapter_form(_form, "test"), do: nil
   end

--- a/lib/keila_web/views/sender_view.ex
+++ b/lib/keila_web/views/sender_view.ex
@@ -1,3 +1,34 @@
 defmodule KeilaWeb.SenderView do
   use KeilaWeb, :view
+
+  def sender_adapters do
+    Keila.Mailings.SenderAdapters.adapter_names()
+  end
+
+  def sender_adapter_name("smtp"), do: "SMTP"
+  def sender_adapter_name("ses"), do: "SES"
+  def sender_adapter_name("sendgrid"), do: "Sendgrid"
+  def sender_adapter_name("mailgun"), do: "Mailgun"
+  if Mix.env() == :test do
+    def sender_adapter_name("test"), do: "Test"
+  end
+
+  def render_sender_adapter_form(form, "smtp") do
+    render("_smtp_config.html", form: form)
+  end
+
+  def render_sender_adapter_form(form, "ses") do
+    render("_ses_config.html", form: form)
+  end
+
+  def render_sender_adapter_form(form, "sendgrid") do
+    render("_sendgrid_config.html", form: form)
+  end
+
+  def render_sender_adapter_form(form, "mailgun") do
+    render("_mailgun_config.html", form: form)
+  end
+  if Mix.env() == :test do
+    def render_sender_adapter_form(_form, "test"), do: nil
+  end
 end

--- a/test/keila/mailings/mailings_campaign_test.exs
+++ b/test/keila/mailings/mailings_campaign_test.exs
@@ -76,7 +76,7 @@ defmodule Keila.MailingsCampaignTest do
     |> Enum.chunk_every(10_000)
     |> Enum.each(fn params -> Repo.insert_all(Contacts.Contact, params) |> elem(1) end)
 
-    sender = insert!(:mailings_sender, config: %Mailings.Sender.Config{})
+    sender = insert!(:mailings_sender, config: %Mailings.Sender.Config{type: "test"})
     campaign = insert!(:mailings_campaign, project_id: project.id, sender_id: sender.id)
     Mailings.deliver_campaign(campaign.id)
 

--- a/test/keila_web/controllers/campaign_controller_test.exs
+++ b/test/keila_web/controllers/campaign_controller_test.exs
@@ -128,7 +128,7 @@ defmodule KeilaWeb.CampaignControllerTest do
       campaign =
         insert!(:mailings_campaign,
           project_id: project.id,
-          sender: build(:mailings_sender, config: %{type: nil})
+          sender: build(:mailings_sender, config: %{type: "test"})
         )
 
       _contacts = insert_n!(:contact, 10, fn _ -> %{project_id: project.id} end)

--- a/test/support/test_sender_adapter.ex
+++ b/test/support/test_sender_adapter.ex
@@ -1,0 +1,15 @@
+defmodule Keila.TestSenderAdapter do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "test"
+
+  @impl true
+  def schema_fields, do: []
+
+  @impl true
+  def changeset(changeset, _params), do: changeset
+
+  @impl true
+  def to_swoosh_config(_struct), do: []
+end


### PR DESCRIPTION
This patch moves sender adapter specific code into a centralized place so that adding support for more sender adapters becomes easier.
This should aid us in adding support for all adapters supported by Swoosh.
The UI currently still needs to define views and "translations" for the adapter names explicitly to allow more freedom.

One side effect to this is that we can't reference `Keila.Mailings.Sender.Config` in the adapter code since that would introduce cyclic dependencies.

Currently, the UI code needs to define some methods to handle the test sender adapter. That's not great but I wonder if we even need to support a test specific adapter or if we can use the `SMTP` adapter in all cases?

This is meant to provide a starting point for a discussion so I'm not saying that this needs to be the final solution.

Let me know what you think.