### PR TITLE
Concurrency, Prevent double sending of Campaigns

### DIFF
--- a/test/keila/mailings/mailings_campaign_test.exs
+++ b/test/keila/mailings/mailings_campaign_test.exs
@@ -98,4 +98,20 @@ defmodule Keila.MailingsCampaignTest do
     assert {:error, :no_recipients} = Mailings.deliver_campaign(campaign.id)
     assert %{sent_at: nil} = Mailings.get_campaign(campaign.id)
   end
+
+  @tag :mailings_campaign
+  test "campaign that has been delivered is not delivered again", %{project: project} do
+    sender = insert!(:mailings_sender, config: %Mailings.Sender.Config{type: "test"})
+    sent_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    campaign =
+      insert!(:mailings_campaign,
+        project_id: project.id,
+        sender_id: sender.id,
+        sent_at: sent_at
+      )
+
+    assert {:error, :already_sent} = Mailings.deliver_campaign(campaign.id)
+    assert %{sent_at: ^sent_at} = Mailings.get_campaign(campaign.id)
+  end
 end


### PR DESCRIPTION
While trying to implement the deliver campaign later feature I noticed that we didn't properly guard against double sendings of campaigns.
The idea here is to use lock on the campaign and use `sent_at` as a guard to ensure that the campaign is not sended twice.

This came up since I tried to implement the send later feature for campaigns based on a new `deliver_at` field in combination with a Oban cron job rather than just scheduling jobs for each scheduled campaign.
The benefit of that is more control over sending of those scheduled campaigns and having the knowledge about the time the campaign will be delivered inside the domain rather than having it only inside Oban (or introducing a potential disconnect between those sources of truth).
Based on my experience this pattern is better scalable and adjustable for different needs than just scheduling jobs in the future.