### PR TITLE
Add purge config for TailwindCSS to reduce CSS bundle size

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -3,7 +3,7 @@
   "description": " ",
   "license": "MIT",
   "scripts": {
-    "deploy": "webpack --mode production",
+    "deploy": "NODE_ENV=production webpack --mode production",
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,5 +1,10 @@
 module.exports = {
-  purge: [],
+  purge: [
+    '../lib/**/*.ex',
+    '../lib/**/*.leex',
+    '../lib/**/*.eex',
+    './js/**/*.js'
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},
@@ -12,7 +17,7 @@ module.exports = {
       ringOffsetWidth: ['responsive', 'focus-within', 'focus', 'hover'],
       ringOpacity: ['responsive', 'focus-within', 'focus', 'hover'],
       ringWidth: ['responsive', 'focus-within', 'focus', 'hover'],
-  
+      
     },
   },
   plugins: [require('@tailwindcss/forms')],

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = (env, options) => {
           use: [
             MiniCssExtractPlugin.loader,
             'css-loader',
-            "postcss-loader",
+            'postcss-loader',
             'sass-loader',
           ],
         },


### PR DESCRIPTION
@wmnnd this should fix #28 

Could you check it out and run it locally using `MIX_ENV=prod mix phx.server` and confirm that it changes from something around this

<img width="503" alt="Screenshot 2021-02-25 at 20 00 42" src="https://user-images.githubusercontent.com/16822008/109211273-eb8b0d80-77a5-11eb-82d9-56232a785332.png">

to something looking more like this?

<img width="503" alt="Screenshot 2021-02-25 at 20 00 34" src="https://user-images.githubusercontent.com/16822008/109211297-f5147580-77a5-11eb-85d2-002d52e665b3.png">

I did have some issues with what I suspect was my local webpack cache, so ping me if it doesn't (and I'll share more insights)!