### PR TITLE
Fix 'email is invalid' error when running seeds

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -18,7 +18,9 @@ if Keila.Repo.all(Auth.Group) == [] do
         email
 
       _empty ->
-        Logger.warn("KEILA_USER not set. Creating root user with email: root@localhost")
+        email = "root@localhost.dev"
+        Logger.warn("KEILA_USER not set. Creating root user with email: root@localhost.dev")
+        email
     end
 
   password =


### PR DESCRIPTION
Just ran into `[error] Failed to create root user: %{email: ["is invalid"]}` when trying to run the seeds on the `0.2` release.

This PR should fix the problem, didn't bother with opening a corresponding issue.


@wmnnd @Jcambass I really like this approach in terms of user ergonomics. It's a sweet mix of _not_ having an openly configurable application waiting to be abused (since there's a password & email set) and not having to know Elixir/jumping into `IEX` to manually create records! 🙌🏽 