### PR TITLE
Feature/send later UI

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -24,7 +24,7 @@ html {
 }
 
 .button {
-    @apply rounded inline-flex flex-nowrap whitespace-nowrap px-2 py-1 gap-2 outline-none items-center;
+    @apply rounded inline-flex flex-nowrap whitespace-nowrap px-2 py-1 gap-2 outline-none items-center focus:outline-none;
 
     svg {
         @apply w-6;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,7 +20,12 @@ import NProgress from "nprogress"
 import { LiveSocket } from "phoenix_live_view"
 
 import * as CampaignEditLiveHooks from "./hooks/campaign-edit-live"
-const Hooks = { ...CampaignEditLiveHooks }
+import * as DateTimeHooks from "./hooks/date-time"
+
+const Hooks = { ...DateTimeHooks, ...CampaignEditLiveHooks }
+
+// Make hooks available globally
+window.Hooks = Hooks
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken }, hooks: Hooks })

--- a/assets/js/hooks/date-time.js
+++ b/assets/js/hooks/date-time.js
@@ -1,0 +1,52 @@
+/**
+ * This hook can be used on inputs with type=time.
+ * Specify a UTC ISO 8601 string as data-value.
+ */
+export const SetLocalTimeValue = {
+    mounted() {
+      const rawDate = this.el.dataset.value
+      if (!rawDate) return
+  
+      const date = new Date(rawDate)
+      const h = date.getHours() < 10 ? "0" + date.getHours() : date.getHours()
+      const m = date.getMinutes() < 10 ? "0" + date.getMinutes() : date.getMinutes()
+      this.el.value = `${h}:${m}`
+    }
+  }
+  
+/**
+ * This hook can be used on inputs with type=date.
+ * Specify a UTC ISO 8601 string as data-value.
+ */
+export const SetLocalDateValue = {
+    mounted() {
+      const rawDate = this.el.dataset.value
+      if (!rawDate) return
+  
+      const date = new Date(rawDate)
+      const y = date.getFullYear()
+      const m = (date.getMonth() + 1) < 10 ? "0" + (date.getMonth() + 1) : (date.getMonth() + 1)
+      const d = date.getDate() < 10 ? "0" + date.getDate() : date.getDate()
+      this.el.value = `${y}-${m}-${d}`
+    }
+}
+  
+/**
+ * This hook replaces the inner text of an element with a formatted local date.
+ * Specify a UTC ISO 8601 string as data-value.
+ */
+const putLocalDateTime = el => {
+    const rawDate = el.dataset.value
+    if (!rawDate) return
+
+    const date = new Date(rawDate)
+    el.innerText = date.toLocaleString(undefined, { weekday: "short", year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit'  })
+}
+export const SetLocalDateTimeContent = {
+    mounted() {
+        putLocalDateTime(this.el)
+    },
+    updated() {
+        putLocalDateTime(this.el)
+    }
+}

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :keila, Keila.Id,
 
 config :keila, Keila.Mailings,
   # Minimum offset in seconds between current time and allowed scheduling time
-  campaign_schedule_offset: 300
+  min_campaign_schedule_offset: 300
 
 config :keila, Keila.Mailings.SenderAdapters,
   adapters: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -64,6 +64,9 @@ config :keila, Oban,
      ]}
   ]
 
+# Use Timezone database
+config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,10 @@ config :keila, Keila.Id,
   salt: "bF4QzDjqV",
   min_len: 8
 
+config :keila, Keila.Mailings,
+  # Minimum offset in seconds between current time and allowed scheduling time
+  campaign_schedule_offset: 300
+
 config :keila, Keila.Mailings.SenderAdapters,
   adapters: [
     Keila.Mailings.SenderAdapters.SMTP,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -32,6 +32,15 @@ config :keila, KeilaWeb.Endpoint,
     ]
   ]
 
+config :keila, Keila.Mailings.SenderAdapters,
+  adapters: [
+    Keila.Mailings.SenderAdapters.SMTP,
+    Keila.Mailings.SenderAdapters.Sendgrid,
+    Keila.Mailings.SenderAdapters.SES,
+    Keila.Mailings.SenderAdapters.Mailgun,
+    Keila.Mailings.SenderAdapters.Local
+  ]
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,9 @@ config :argon2_elixir, t_cost: 1, m_cost: 8
 # Disable Oban Queues
 config :keila, Oban, queues: false, plugins: false
 
+config :keila, Keila.Mailings,
+  campaign_schedule_offset: -10
+
 # Only use test and smtp Sender Adapters
 config :keila, Keila.Mailings.SenderAdapters,
   adapters: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,8 +33,8 @@ config :argon2_elixir, t_cost: 1, m_cost: 8
 # Disable Oban Queues
 config :keila, Oban, queues: false, plugins: false
 
-config :keila, Keila.Mailings,
-  campaign_schedule_offset: -10
+# Allow scheduling campaigns at utc_now
+config :keila, Keila.Mailings, min_campaign_schedule_offset: -10
 
 # Only use test and smtp Sender Adapters
 config :keila, Keila.Mailings.SenderAdapters,

--- a/lib/keila/mailings/mailings.ex
+++ b/lib/keila/mailings/mailings.ex
@@ -186,6 +186,17 @@ defmodule Keila.Mailings do
 
   @doc """
   Schedules the given campaign to be delivered in the future.
+
+  Campaigns can be re-scheduled or unscheduled (`%{scheduled_for: nil}`).
+
+  `config :keila, Keila.Mailings, :campaign_schedule_offset` determines the
+  threshold until when (relative to the current time) a campaign can be
+  scheduled, re-scheduled or unscheduled.
+
+  If `:campaign_schedule_offset` is set to 60 seconds, campaigns can only be
+  scheduled for times at least one minute after the current time.
+  Their schedule can  only be modified if there's at least one minute left
+  before the campaign was originally scheduled to be delivered.
   """
   @spec schedule_campaign(Campaign.id(), map()) ::
           {:ok, Campaign.t()} | {:error, Changeset.t(Campaign.t())}

--- a/lib/keila/mailings/mailings.ex
+++ b/lib/keila/mailings/mailings.ex
@@ -113,8 +113,8 @@ defmodule Keila.Mailings do
   If `use_send_changeset?` is set to `true`, a different changeset that
   validates whether campaign is ready to be sent is used.
   """
-  @spec update_campaign(Campaign.id(), map()) ::
-          {:ok, Campaign.t(), boolean()} | {:error, Changeset.t(Campaign.t())}
+  @spec update_campaign(Campaign.id(), map(), boolean()) ::
+          {:ok, Campaign.t()} | {:error, Changeset.t(Campaign.t())}
   def update_campaign(id, params, use_send_changeset? \\ false)
 
   def update_campaign(id, params, false) when is_id(id) do

--- a/lib/keila/mailings/mailings.ex
+++ b/lib/keila/mailings/mailings.ex
@@ -241,7 +241,7 @@ defmodule Keila.Mailings do
 
     Keila.Contacts.stream_project_contacts(campaign.project_id, [])
     |> Enum.map(fn contact ->
-      now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive()
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
       %{contact_id: contact.id, campaign_id: campaign.id, inserted_at: now, updated_at: now}
     end)
     |> Stream.chunk_every(1000)

--- a/lib/keila/mailings/mailings.ex
+++ b/lib/keila/mailings/mailings.ex
@@ -189,11 +189,11 @@ defmodule Keila.Mailings do
 
   Campaigns can be re-scheduled or unscheduled (`%{scheduled_for: nil}`).
 
-  `config :keila, Keila.Mailings, :campaign_schedule_offset` determines the
+  `config :keila, Keila.Mailings, :min_campaign_schedule_offset` determines the
   threshold until when (relative to the current time) a campaign can be
   scheduled, re-scheduled or unscheduled.
 
-  If `:campaign_schedule_offset` is set to 60 seconds, campaigns can only be
+  If `:min_campaign_schedule_offset` is set to 60 seconds, campaigns can only be
   scheduled for times at least one minute after the current time.
   Their schedule can  only be modified if there's at least one minute left
   before the campaign was originally scheduled to be delivered.

--- a/lib/keila/mailings/schemas/campaign.ex
+++ b/lib/keila/mailings/schemas/campaign.ex
@@ -47,6 +47,45 @@ defmodule Keila.Mailings.Campaign do
   def schedule_changeset(struct = %__MODULE__{}, params) do
     struct
     |> cast(params, [:scheduled_for])
-    |> validate_required([:scheduled_for])
+    |> validate_scheduled_for()
+  end
+
+  defp validate_scheduled_for(changeset) do
+    changeset
+    |> maybe_validate_old_scheduled_for()
+    |> validate_change(:scheduled_for, &maybe_validate_new_scheduled_for/2)
+  end
+
+  defp maybe_validate_old_scheduled_for(changeset = %{data: %__MODULE__{scheduled_for: nil}}),
+    do: changeset
+
+  defp maybe_validate_old_scheduled_for(changeset) do
+    scheduled_for = changeset.data.scheduled_for
+    {_offset, threshold} = campaign_schedule_offset_and_threshold()
+
+    case DateTime.compare(threshold, scheduled_for) do
+      :gt -> add_error(changeset, :scheduled_for, "is already about to be delivered")
+      _ -> changeset
+    end
+  end
+
+  defp maybe_validate_new_scheduled_for(:scheduled_for, nil), do: []
+
+  defp maybe_validate_new_scheduled_for(:scheduled_for, scheduled_for) do
+    {offset, threshold} = campaign_schedule_offset_and_threshold()
+
+    case DateTime.compare(threshold, scheduled_for) do
+      :gt -> [scheduled_for: "must be at least #{offset} seconds in the future"]
+      _ -> []
+    end
+  end
+
+  defp campaign_schedule_offset_and_threshold() do
+    offset =
+      Application.get_env(:keila, Keila.Mailings, []) |> Keyword.get(:campaign_schedule_offset, 0)
+
+    threshold = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.add(offset, :second)
+
+    {offset, threshold}
   end
 end

--- a/lib/keila/mailings/schemas/campaign.ex
+++ b/lib/keila/mailings/schemas/campaign.ex
@@ -61,7 +61,7 @@ defmodule Keila.Mailings.Campaign do
 
   defp maybe_validate_old_scheduled_for(changeset) do
     scheduled_for = changeset.data.scheduled_for
-    {_offset, threshold} = campaign_schedule_offset_and_threshold()
+    {_offset, threshold} = min_campaign_schedule_offset_and_threshold()
 
     case DateTime.compare(threshold, scheduled_for) do
       :gt -> add_error(changeset, :scheduled_for, "is already about to be delivered")
@@ -72,7 +72,7 @@ defmodule Keila.Mailings.Campaign do
   defp maybe_validate_new_scheduled_for(:scheduled_for, nil), do: []
 
   defp maybe_validate_new_scheduled_for(:scheduled_for, scheduled_for) do
-    {offset, threshold} = campaign_schedule_offset_and_threshold()
+    {offset, threshold} = min_campaign_schedule_offset_and_threshold()
 
     case DateTime.compare(threshold, scheduled_for) do
       :gt -> [scheduled_for: "must be at least #{offset} seconds in the future"]
@@ -80,9 +80,10 @@ defmodule Keila.Mailings.Campaign do
     end
   end
 
-  defp campaign_schedule_offset_and_threshold() do
+  defp min_campaign_schedule_offset_and_threshold() do
     offset =
-      Application.get_env(:keila, Keila.Mailings, []) |> Keyword.get(:campaign_schedule_offset, 0)
+      Application.get_env(:keila, Keila.Mailings, [])
+      |> Keyword.fetch!(:min_campaign_schedule_offset)
 
     threshold = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.add(offset, :second)
 

--- a/lib/keila/mailings/sender_adapters/local.ex
+++ b/lib/keila/mailings/sender_adapters/local.ex
@@ -1,0 +1,21 @@
+defmodule Keila.Mailings.SenderAdapters.Local do
+  use Keila.Mailings.SenderAdapters.Adapter
+
+  @impl true
+  def name, do: "local"
+
+  @impl true
+  def schema_fields do
+    []
+  end
+
+  @impl true
+  def changeset(changeset, params) do
+    changeset
+  end
+
+  @impl true
+  def to_swoosh_config(struct) do
+    [adapter: Swoosh.Adapters.Local]
+  end
+end

--- a/lib/keila/mailings/sender_adapters/local.ex
+++ b/lib/keila/mailings/sender_adapters/local.ex
@@ -10,12 +10,12 @@ defmodule Keila.Mailings.SenderAdapters.Local do
   end
 
   @impl true
-  def changeset(changeset, params) do
+  def changeset(changeset, _params) do
     changeset
   end
 
   @impl true
-  def to_swoosh_config(struct) do
+  def to_swoosh_config(_struct) do
     [adapter: Swoosh.Adapters.Local]
   end
 end

--- a/lib/keila/schema.ex
+++ b/lib/keila/schema.ex
@@ -22,6 +22,7 @@ defmodule Keila.Schema do
       import Ecto.Changeset
       use Ecto.Schema
       use Keila.Id, unquote(opts)
+      @timestamps_opts [type: :utc_datetime]
 
       @type t :: %__MODULE__{}
     end

--- a/lib/keila_web.ex
+++ b/lib/keila_web.ex
@@ -98,6 +98,7 @@ defmodule KeilaWeb do
       import KeilaWeb.PaginationHelpers
       import KeilaWeb.DeleteButtonHelpers
       import KeilaWeb.IconHelper
+      import KeilaWeb.DateTimeHelpers
       import KeilaWeb.Gettext
       alias KeilaWeb.Router.Helpers, as: Routes
     end

--- a/lib/keila_web/live/campaign_edit_live.ex
+++ b/lib/keila_web/live/campaign_edit_live.ex
@@ -7,6 +7,7 @@ defmodule KeilaWeb.CampaignEditLive do
     project = session["current_project"]
     senders = session["senders"]
     campaign = session["campaign"]
+    error_changeset = session["changeset"]
 
     changeset =
       case session["params"] do
@@ -31,6 +32,7 @@ defmodule KeilaWeb.CampaignEditLive do
       |> assign(:senders, senders)
       |> assign(:changeset, changeset)
       |> assign(:recipient_count, recipient_count)
+      |> assign(:error_changeset, error_changeset)
       |> put_default_assigns()
 
     {:ok, socket}

--- a/lib/keila_web/templates/campaign/_send_dialogs.html.leex
+++ b/lib/keila_web/templates/campaign/_send_dialogs.html.leex
@@ -1,0 +1,156 @@
+<div
+    id="send-dialogs"
+    style="display: none"
+    class="fixed z-10 inset-0 overflow-y-auto bg-black bg-opacity-90 flex items-center justify-center"
+    x-on:x-confirm.stop="activeDialog = null"
+    x-show.transition="activeDialog"
+    x-on:x-cancel.stop="activeDialog = null"
+    x-on:x-show.window="activeDialog = ($event.detail && $event.detail.dialog); if (activeDialog) { $nextTick(() => {const el = $el.querySelector(`[data-dialog-for=${activeDialog}] input, [data-dialog-for=${activeDialog}] button`); el.focus()}) }"
+    @change.stop="false"
+    @input.stop="false"
+    @blur.stop="false"
+>
+    <div
+        x-show="activeDialog == 'send'"
+        class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
+        @keydown.escape.prevent="$dispatch('x-cancel')"
+        @click.away="$dispatch('x-cancel')"
+        data-dialog-for="send"
+    >
+        <%= if @recipient_count > 0 do %>
+            <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+                <h2 class="text-3xl">Ready to send your campaign?</h2>
+                <br>
+                <p>
+                    <%=raw gettext("Are you ready to send your campaign <em>%{subject}</em> to %{count} contacts?", subject: Ecto.Changeset.get_field(@changeset, :subject), count: @recipient_count) %>
+                </p>
+                <%= if get_field(@changeset, :scheduled_for) do %>
+                    <br>
+                    <p>
+                        <%= gettext("This campaign has already been scheduled. You can manually send it up to five minutes before the scheduled sending time.") %>
+                    </p>
+                <% end %>
+                <br>
+                <div class="flex justify-end gap-8">
+                    <button class="button button--text button--large" @click.prevent="$dispatch('x-cancel')">
+                        <%= gettext("Cancel") %>
+                    </button>
+                    <button class="button button--cta button--large" action="submit" form="campaign" name="send" value="true">
+                        <%= render_icon(:paper_airplane) %>
+                        <%= gettext("Send") %>
+                    </button>
+                </div>
+            </div>
+        <% else %>
+            <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+                <h2 class="text-3xl"><%= gettext("No Contacts, No Campaign.")%></h2>
+                <br>
+                <p>
+                    <%= gettext("It looks like you don’t yet have any contacts to receive this campaign.") %>
+                </p>
+                <br>
+                <div class="flex justify-end gap-8">
+                    <button class="button button--cta button--large" @click.prevent="$dispatch('x-cancel')">
+                        <%= gettext("Ok") %>
+                    </button>
+                </div>
+            </div>
+        <% end %>
+    </div>
+
+
+    <div
+        x-show="activeDialog == 'schedule'"
+        class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
+        @keydown.esc.prevent="$dispatch('x-cancel')"
+        @click.away="$dispatch('x-cancel')"
+        data-dialog-for="schedule"
+    >
+        <%= if @recipient_count > 0 do %>
+            <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+                <h2 class="text-3xl"><%= gettext("Ready to schedule your campaign?") %></h2>
+                <br>
+                <p>
+                    <%= if get_field(@changeset, :scheduled_for) do %>
+                        <%= gettext("This campaign has already been scheduled. You can reschedule or cancel it up to five minutes before the scheduled sending time.") %>
+                    <% else %>
+                        <%=raw gettext("Are you ready to schedule sending your campaign <em>%{subject}</em> to %{count} contacts?", subject: Ecto.Changeset.get_field(@changeset, :subject), count: @recipient_count) %>
+                    <% end %>
+                </p>
+                <div class="grid gap-4 mt-4">
+                    <div class="flex flex-col">
+                        <label class="font-bold"><%= gettext("Date") %></label>
+                        <input
+                            type="date"
+                            name="schedule[date]"
+                            id="schedule[date]"
+                            phx-hook="SetLocalDateValue"
+                            data-value="<%=raw get_field(@changeset, :scheduled_for) |> maybe_print_datetime() %>"
+                            class="bg-white hover:bg-green-100 text-black"
+                        >
+                    </div>
+                    <div class="flex flex-col">
+                        <label class="font-bold"><%= gettext("Time") %></label>
+                        <input
+                            type="time"
+                            id="schedule[time]"
+                            name="schedule[time]"
+                            class="bg-white hover:bg-green-100 text-black"
+                            phx-hook="SetLocalTimeValue"
+                            data-value="<%=raw get_field(@changeset, :scheduled_for) |> maybe_print_datetime() %>"
+                        >
+                    </div>
+                    <div class="flex flex-col">
+                        <label class="font-bold"><%= gettext("Timezone") %></label>
+                        <input
+                            type="text"
+                            name="schedule[timezone]"
+                            readonly
+                            value="Etc/UTC"
+                            :value="Intl.DateTimeFormat().resolvedOptions().timeZone"
+                            class="bg-transparent text-white"
+                        >
+                    </div>
+                </div>
+
+                <br>
+                <div class="flex justify-end gap-4">
+                    <button class="button button--text button--large" @click.prevent="$dispatch('x-cancel')">
+                        <%= gettext("Cancel") %>
+                    </button>
+                    <%= if get_field(@changeset, :scheduled_for) do %>
+                        <button
+                            class="button button--large"
+                            action="submit"
+                            form="campaign"
+                            name="schedule[cancel]"
+                            value="true"
+                        >
+                            <%= render_icon(:x) %>
+                            <%= gettext("Unschedule") %>
+                        </button>
+                    <% end %>
+                    <button class="button button--cta button--large" action="submit" form="campaign" name="schedule[schedule]" value="true">
+                        <%= render_icon(:clock) %>
+                        <%= gettext("Schedule") %>
+                    </button>
+                </div>
+            </div>
+        <% else %>
+            <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+                <h2 class="text-3xl"><%= gettext("No Contacts, No Campaign.")%></h2>
+                <br>
+                <p>
+                    <%= gettext("It looks like you don’t yet have any contacts to receive this campaign.") %>
+                </p>
+                <br>
+                <div class="flex justify-end gap-8">
+                    <button class="button button--cta button--large" @click.prevent="activeDialog = false">
+                        <%= gettext("Ok") %>
+                    </button>
+                </div>
+            </div>
+        <% end %>
+    </div>
+
+</div>

--- a/lib/keila_web/templates/campaign/edit_live.html.leex
+++ b/lib/keila_web/templates/campaign/edit_live.html.leex
@@ -1,11 +1,11 @@
-<div class="bg-gray-900 text-gray-50" x-data="{showSendDialog: false}">
-    <div class="container py-4 lg:py-8 flex">
+<div class="bg-gray-900 text-gray-50" x-data="{activeDialog: null}">
+    <div class="container py-4 lg:py-8 flex flex-wrap">
         <div class="flex-grow">
             <h1 class="text-2xl sm:text-5xl mb-4">
                 <%= gettext("Edit Campaign") %>
             </h1>
         </div>
-        <div class="flex justify-end gap-4 mb-2 items-center">
+        <div class="flex-grow flex flex-wrap justify-end gap-4 mb-2 items-center">
             <a class="button button--text button--large" href="<%= Routes.campaign_path(@socket, :index, @current_project.id) %>">
                 <%= gettext("Cancel") %>
             </a>
@@ -15,12 +15,25 @@
                 <%= render_icon(:save) %>
                 <%= gettext("Save") %>
             </button>
-            <button class="button button--cta button--large" @click.prevent="showSendDialog = true">
+            <button class="button button--large <%= if is_nil(get_field(@changeset, :scheduled_for)), do: "button--cta" %>" @click.prevent="$dispatch('x-show', { dialog: 'schedule' })">
+                <%= render_icon(:clock) %>
+                <%= gettext("Schedule") %>
+            </button>
+            <button class="button button--large <%= if is_nil(get_field(@changeset, :scheduled_for)), do: "button--cta" %>" @click.prevent="$dispatch('x-show', { dialog: 'send' })">
                 <%= render_icon(:paper_airplane) %>
                 <%= gettext("Send") %>
             </button>
         </div>
     </div>
+
+    <%= if @error_changeset do %>
+        <div class="container mb-4">
+            <div class="bg-red-500 text-white p-4">
+                <%= with_errors(@error_changeset, :scheduled_for) do [gettext("There was an error scheduling your campaign:")] end %>
+                <%= with_errors(@error_changeset, :sender_id) do [gettext("You must specify a sender before sending/scheduling a campaign:")] end %>
+            </div>
+        </div>
+    <% end %>
 
     <div class="container pb-8">
         <%= form_for(@changeset, Routes.campaign_path(@socket, :post_edit, @current_project.id, @campaign.id), [id: "campaign", class: "flex flex-col gap-4", phx_change: "form_updated"], fn f -> %>
@@ -102,45 +115,9 @@
 
             </div>
 
-        <% end) %>
-    </div>
+            <%= render("_send_dialogs.html", assigns) %>
 
-    <div class="fixed z-10 inset-0 overflow-y-auto bg-black bg-opacity-90" x-show.transition="showSendDialog" style="display: none">
-    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        <%= if @recipient_count > 0 do %>
-        <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
-            <h2 class="text-3xl">Ready to send your campaign?</h2>
-                <br>
-                <p>
-                    <%=raw gettext("Are you ready to send your campaign <em>%{subject}</em> to %{count} contacts?", subject: Ecto.Changeset.get_field(@changeset, :subject), count: @recipient_count) %>
-                </p>
-                <br>
-                <div class="flex justify-end gap-8">
-                    <button class="button button--text button--large" @click.prevent="showSendDialog = false">
-                        <%= gettext("Cancel") %>
-                    </button>
-                    <button class="button button--cta button--large" action="submit" form="campaign" name="campaign[send]" value="true">
-                        <%= render_icon(:paper_airplane) %>
-                        <%= gettext("Send") %>
-                    </button>
-                </div>
-        </div>
-        <% else %>
-            <div class="inline-block align-bottom bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-8" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
-                <h2 class="text-3xl"><%= gettext("No Contacts, No Campaign.")%></h2>
-                <br>
-                <p>
-                    <%= gettext("It looks like you don’t yet have any contacts to receive this campaign.") %>
-                </p>
-                <br>
-                <div class="flex justify-end gap-8">
-                    <button class="button button--cta button--large" @click.prevent="showSendDialog = false">
-                        <%= gettext("Ok") %>
-                    </button>
-                </div>
-            </div>
-        <% end %>
-        </div>
+        <% end) %>
     </div>
 </div>
 

--- a/lib/keila_web/templates/campaign/index.html.leex
+++ b/lib/keila_web/templates/campaign/index.html.leex
@@ -38,15 +38,24 @@
                 <p class="text-sm">
                     <%= gettext("Created at: %{date}", date: Calendar.strftime(campaign.inserted_at, "%a, %b %d %Y, %H:%M")) %>
                 </p>
-                <%= if campaign.sent_at do %>
-                    <p class="text-sm">
-                        <%= gettext("Sent at: %{date}", date: Calendar.strftime(campaign.sent_at, "%a, %b %d %Y, %H:%M")) %>
-                    </p>
-                <% else %>
-                    <p class="text-sm">
-                        <br>
-                    </p>
-                <% end %>
+                <p class="text-sm flex items-center gap-2 mt-4">
+                    <%= cond do
+                        campaign.sent_at ->
+                            [
+                                content_tag(:span, render_icon(:paper_airplane), class: "inline-flex h-5 w-5"),
+                                gettext("Sent at: %{date}", date: Calendar.strftime(campaign.sent_at, "%a, %b %d %Y, %H:%M"))
+                            ]
+
+                        campaign.scheduled_for ->
+                            [
+                                content_tag(:span, render_icon(:clock), class: "inline-flex h-5 w-5"),
+                                gettext("Scheduled for: %{date}", date: Calendar.strftime(campaign.scheduled_for, "%a, %b %d %Y, %H:%M"))
+                            ]
+
+                        true ->
+                            gettext("Not yet sent.")
+                    end %>
+                </p>
                 <br>
                 <%= if is_nil(campaign.sent_at) do %>
                     <a href="<%= Routes.campaign_path(@conn, :edit, @current_project.id, campaign.id) %>" class="button">

--- a/lib/keila_web/templates/campaign/index.html.leex
+++ b/lib/keila_web/templates/campaign/index.html.leex
@@ -35,25 +35,30 @@
                 <h2 class="font-light text-2xl flex items-center gap-2 mb-2">
                     <%= campaign.subject %>
                 </h2>
-                <p class="text-sm">
-                    <%= gettext("Created at: %{date}", date: Calendar.strftime(campaign.inserted_at, "%a, %b %d %Y, %H:%M")) %>
-                </p>
-                <p class="text-sm flex items-center gap-2 mt-4">
+                <p class="text-sm flex items-center gap-2">
                     <%= cond do
                         campaign.sent_at ->
                             [
-                                content_tag(:span, render_icon(:paper_airplane), class: "inline-flex h-5 w-5"),
-                                gettext("Sent at: %{date}", date: Calendar.strftime(campaign.sent_at, "%a, %b %d %Y, %H:%M"))
+                                content_tag(:span, render_icon(:cake), class: "inline-flex h-5 w-5"),
+                                gettext("Sent at:"),
+                                " ",
+                                local_date_time_tag(campaign.sent_at)
                             ]
 
                         campaign.scheduled_for ->
                             [
                                 content_tag(:span, render_icon(:clock), class: "inline-flex h-5 w-5"),
-                                gettext("Scheduled for: %{date}", date: Calendar.strftime(campaign.scheduled_for, "%a, %b %d %Y, %H:%M"))
+                                gettext("Scheduled for:"),
+                                " ",
+                                local_date_time_tag(campaign.scheduled_for)
                             ]
 
                         true ->
-                            gettext("Not yet sent.")
+                            [
+                                gettext("Updated at:"),
+                                " ",
+                                local_date_time_tag(campaign.updated_at)
+                            ]
                     end %>
                 </p>
                 <br>

--- a/lib/keila_web/templates/campaign/index.html.leex
+++ b/lib/keila_web/templates/campaign/index.html.leex
@@ -42,7 +42,7 @@
                                 content_tag(:span, render_icon(:cake), class: "inline-flex h-5 w-5"),
                                 gettext("Sent at:"),
                                 " ",
-                                local_date_time_tag(campaign.sent_at)
+                                local_datetime_tag(campaign.sent_at)
                             ]
 
                         campaign.scheduled_for ->
@@ -50,14 +50,14 @@
                                 content_tag(:span, render_icon(:clock), class: "inline-flex h-5 w-5"),
                                 gettext("Scheduled for:"),
                                 " ",
-                                local_date_time_tag(campaign.scheduled_for)
+                                local_datetime_tag(campaign.scheduled_for)
                             ]
 
                         true ->
                             [
                                 gettext("Updated at:"),
                                 " ",
-                                local_date_time_tag(campaign.updated_at)
+                                local_datetime_tag(campaign.updated_at)
                             ]
                     end %>
                 </p>

--- a/lib/keila_web/templates/campaign/stats_live.html.leex
+++ b/lib/keila_web/templates/campaign/stats_live.html.leex
@@ -47,7 +47,7 @@
 
         <% :sent -> %>
             <p class="flex gap-4 items-center">
-                <%= render_icon(:cake) %>
+                <span class="inline-flex h-20 w-20"><%= render_icon(:cake) %></span>
                 <%= gettext("This campaign has been successfully sent out to %{count} recipients.", count: @stats.sent_count) %>
             </p>
         <% end %>

--- a/lib/keila_web/templates/sender/_local_config.html.eex
+++ b/lib/keila_web/templates/sender/_local_config.html.eex
@@ -1,0 +1,6 @@
+<div class="flex flex-col">
+    <%= gettext(
+        "The local sender adapter is useful for testing during development. Inspect its mailbox at: %{url}",
+        url: Routes.static_url(KeilaWeb.Endpoint, "/dev/mailbox")
+    ) %>
+</div>

--- a/lib/keila_web/views/campaign_view.ex
+++ b/lib/keila_web/views/campaign_view.ex
@@ -1,5 +1,6 @@
 defmodule KeilaWeb.CampaignView do
   use KeilaWeb, :view
+  import Ecto.Changeset, only: [get_field: 2]
 
   def plain_text_preview(text) do
     """

--- a/lib/keila_web/views/helpers/date_time_helpers.ex
+++ b/lib/keila_web/views/helpers/date_time_helpers.ex
@@ -1,0 +1,21 @@
+defmodule KeilaWeb.DateTimeHelpers do
+  @moduledoc """
+  Helper module for printing span tags with date time content.
+  Content is automatically translated and localized client-side via hook.
+  """
+
+  use Phoenix.HTML
+
+  @spec local_date_time_tag(DateTime.t()) :: Phoenix.HTML.safe()
+  def local_date_time_tag(datetime = %DateTime{}) do
+    content_tag(
+        :span,
+        Calendar.strftime(datetime, "%a, %b %d %Y, %H:%M"),
+        data_value: DateTime.to_iso8601(datetime),
+        x_data: "{}",
+        x_init: "Hooks.SetLocalDateTimeContent.mounted.call({el: $el})"
+    )
+  end
+
+  def local_date_time_tag(_), do: []
+end

--- a/lib/keila_web/views/helpers/date_time_helpers.ex
+++ b/lib/keila_web/views/helpers/date_time_helpers.ex
@@ -1,21 +1,31 @@
 defmodule KeilaWeb.DateTimeHelpers do
   @moduledoc """
-  Helper module for printing span tags with date time content.
-  Content is automatically translated and localized client-side via hook.
+  Helper module for handling datetimes in views.
   """
 
   use Phoenix.HTML
 
-  @spec local_date_time_tag(DateTime.t()) :: Phoenix.HTML.safe()
-  def local_date_time_tag(datetime = %DateTime{}) do
+  @doc """
+  Render `span` tag with formatted UTC date.
+  The date is automatically translated and localized client-side via hook.
+  """
+  @spec local_datetime_tag(DateTime.t()) :: Phoenix.HTML.safe()
+  def local_datetime_tag(datetime = %DateTime{}) do
     content_tag(
-        :span,
-        Calendar.strftime(datetime, "%a, %b %d %Y, %H:%M"),
-        data_value: DateTime.to_iso8601(datetime),
-        x_data: "{}",
-        x_init: "Hooks.SetLocalDateTimeContent.mounted.call({el: $el})"
+      :span,
+      Calendar.strftime(datetime, "%a, %b %d %Y, %H:%M"),
+      data_value: DateTime.to_iso8601(datetime),
+      x_data: "{}",
+      x_init: "Hooks.SetLocalDateTimeContent.mounted.call({el: $el})"
     )
   end
 
-  def local_date_time_tag(_), do: []
+  def local_datetime_tag(_), do: []
+
+  @doc """
+  Returns a datetime in ISO 8601 format or an empty string if given `nil`.
+  """
+  @spec maybe_print_datetime(DateTime.t() | nil) :: String.t()
+  def maybe_print_datetime(datetime = %DateTime{}), do: DateTime.to_iso8601(datetime)
+  def maybe_print_datetime(_), do: ""
 end

--- a/lib/keila_web/views/helpers/error_helpers.ex
+++ b/lib/keila_web/views/helpers/error_helpers.ex
@@ -24,6 +24,24 @@ defmodule KeilaWeb.ErrorHelpers do
     end
   end
 
+  @doc """
+  Generates a tag only if there is a form/changeset error.
+  """
+  def with_errors(form, field, [{:do, content}]) do
+    case get_errors(form, field) do
+      [] ->
+        []
+
+      errors ->
+        [
+          content,
+          content_tag(:p, class: "form-errors") do
+            errors
+          end
+        ]
+    end
+  end
+
   defp get_errors(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
       content_tag(:span, translate_error(error), class: "invalid-feedback")

--- a/lib/keila_web/views/sender_view.ex
+++ b/lib/keila_web/views/sender_view.ex
@@ -14,6 +14,10 @@ defmodule KeilaWeb.SenderView do
     def sender_adapter_name("test"), do: "Test"
   end
 
+  if Mix.env() == :dev do
+    def sender_adapter_name("local"), do: "Local"
+  end
+
   def render_sender_adapter_form(form, "smtp") do
     render("_smtp_config.html", form: form)
   end
@@ -32,5 +36,11 @@ defmodule KeilaWeb.SenderView do
 
   if Mix.env() == :test do
     def render_sender_adapter_form(_form, "test"), do: nil
+  end
+
+  if Mix.env() == :dev do
+    def render_sender_adapter_form(form, "local") do
+      render("_local_config.html", form: form)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,8 @@ defmodule Keila.MixProject do
       {:nimble_csv, "~> 1.1"},
       {:oban, "~> 2.4.3"},
       {:solid, "~> 0.4.0"},
-      {:earmark, "~> 1.4"}
+      {:earmark, "~> 1.4"},
+      {:tzdata, "~> 1.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -53,5 +53,6 @@
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.0", "da9d49ee7e6bb1c259d36ce6539cd45ae14d81247a2b0c90edf55e2b50507f7b", [:mix], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "5cfe67ad464b243835512aa44321cee91faed6ea868d7fb761d7016e02915c3d"},
   "telemetry_poller": {:hex, :telemetry_poller, "0.5.1", "21071cc2e536810bac5628b935521ff3e28f0303e770951158c73eaaa01e962a", [:rebar3], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "4cab72069210bc6e7a080cec9afffad1b33370149ed5d379b81c7c5f0c663fd4"},
+  "tzdata": {:hex, :tzdata, "1.1.0", "72f5babaa9390d0f131465c8702fa76da0919e37ba32baa90d93c583301a8359", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "18f453739b48d3dc5bcf0e8906d2dc112bb40baafe2c707596d89f3c8dd14034"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/keila/contacts/contacts_query_test.exs
+++ b/test/keila/contacts/contacts_query_test.exs
@@ -44,28 +44,28 @@ defmodule Keila.ContactsQueryTest do
       insert!(:contact, %{
         email: "a@example.com",
         first_name: "A",
-        inserted_at: ~N[2020-01-01 10:01:00Z]
+        inserted_at: ~U[2020-01-01 10:01:00Z]
       })
 
     c2 =
       insert!(:contact, %{
         email: "b@example.com",
         first_name: "B",
-        inserted_at: ~N[2020-01-01 10:02:00Z]
+        inserted_at: ~U[2020-01-01 10:02:00Z]
       })
 
     c3 =
       insert!(:contact, %{
         email: "c@example.com",
         first_name: "C",
-        inserted_at: ~N[2020-02-01 10:01:00Z]
+        inserted_at: ~U[2020-02-01 10:01:00Z]
       })
 
     c4 =
       insert!(:contact, %{
         email: "d@example.com",
         first_name: "D",
-        inserted_at: ~N[2020-02-01 10:02:00Z]
+        inserted_at: ~U[2020-02-01 10:02:00Z]
       })
 
     [c1, c2, c3, c4]

--- a/test/keila/mailings/mailings_campaign_test.exs
+++ b/test/keila/mailings/mailings_campaign_test.exs
@@ -70,7 +70,7 @@ defmodule Keila.MailingsCampaignTest do
   test "deliver campaign", %{project: project} do
     n = @delivery_n
 
-    now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     build_n(:contact, n, fn _ -> %{project_id: project.id} end)
     |> Enum.map(&Map.take(&1, [:name, :project_id, :email, :first_name, :last_name]))
@@ -121,7 +121,7 @@ defmodule Keila.MailingsCampaignTest do
   test "deliver scheduled campaign", %{project: project} do
     n = @delivery_n
 
-    now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_naive()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     build_n(:contact, n, fn _ -> %{project_id: project.id} end)
     |> Enum.map(&Map.take(&1, [:name, :project_id, :email, :first_name, :last_name]))


### PR DESCRIPTION
Here’s the preliminary interface for scheduling campaigns:
![Screenshot_2021-03-07 Open Source Newsletter Tool · Keila](https://user-images.githubusercontent.com/7488303/110232697-8c549800-7f1f-11eb-904f-c372173902db.png)

There’s no code in this MR yet (the commits are just here because it’s based on the WYSIWYG branch), but I’m looking for feedback on a little API question. Right now, (un)scheduling a campaign works via `schedule_campaign/2`. I would like to enforce rules for scheduling campaigns, e.g. that they can only be scheduled for times that are at least `n` minutes in the future or that they can’t be rescheduled/unscheduled if they’ve already been scheduled to be sent out in less than `n` minutes.

My idea was to add an option to `schedule_campaign/2` (turning it into `schedule_campaign/3`) that would allow us to pass this `n` and then use it in a changeset validation.
I don’t think I’ve seen this pattern before, so I’m curious what you think.

An obvious alternative would be to use the application configuration for setting `n`.