### PR TITLE
Simple sender validation

### DIFF
--- a/lib/keila/mailings/mailings.ex
+++ b/lib/keila/mailings/mailings.ex
@@ -57,6 +57,25 @@ defmodule Keila.Mailings do
   end
 
   @doc """
+  Tests if emails can be sent from  Sender credentials with given ID.
+  """
+  @spec try_credentials(Sender.id()) :: {:ok, Sender.t()} | {:error, term()}
+  def try_credentials(id) when is_id(id) do
+    sender = get_sender(id)
+
+    email = %Swoosh.Email{
+      to: [{"", "sender-test@keila.io"}],
+      from: {sender.from_name, sender.from_email},
+      text_body: "Testing sender #{sender.id}"
+    }
+
+    case Keila.Mailer.deliver(email, Sender.Config.to_swoosh_config(sender.config)) do
+      {:ok, _} -> {:ok, sender}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Retrieves Campaign with given `id`.
   """
   @spec get_campaign(Campaign.id()) :: Campaign.t() | nil

--- a/lib/keila_web/controllers/sender_controller.ex
+++ b/lib/keila_web/controllers/sender_controller.ex
@@ -66,7 +66,12 @@ defmodule KeilaWeb.SenderController do
 
       _ ->
         conn
-        |> put_flash(:error, gettext("Sender settings were saved but Keila was unable to send a test email with your provided credentials."))
+        |> put_flash(
+          :error,
+          gettext(
+            "Sender settings were saved but Keila was unable to send a test email with your provided credentials."
+          )
+        )
         |> redirect(to: Routes.sender_path(conn, :index, project.id))
     end
   end

--- a/lib/keila_web/controllers/template_controller.ex
+++ b/lib/keila_web/controllers/template_controller.ex
@@ -7,9 +7,6 @@ defmodule KeilaWeb.TemplateController do
 
   plug :authorize when not (action in [:index, :new, :post_new, :delete])
 
-  @default_text_body File.read!("priv/email_templates/default-text-content.txt")
-  @default_markdown_body File.read!("priv/email_templates/default-markdown-content.md")
-
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     templates = Templates.get_project_templates(current_project(conn).id)

--- a/lib/keila_web/endpoint.ex
+++ b/lib/keila_web/endpoint.ex
@@ -24,8 +24,7 @@ defmodule KeilaWeb.Endpoint do
     at: "/",
     from: :keila,
     gzip: false,
-    only:
-      ~w(css fonts images js favicon.ico robots.txt keila_import_template.csv keila_import_template.ods)
+    only: ~w(css fonts images js downloads favicon.ico robots.txt)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/keila_web/templates/layout/app.html.eex
+++ b/lib/keila_web/templates/layout/app.html.eex
@@ -3,7 +3,7 @@
         <p class="container py-5 my-0"><%= get_flash(@conn, :info) %></p>
     </div>
 <% end %>
-<%= if get_flash(@conn, :errors) do %>
+<%= if get_flash(@conn, :error) do %>
     <div class="bg-yellow-200" role="alert">
         <p class="container py-5 my-0"><%= get_flash(@conn, :error) %></p>
     </div>

--- a/test/keila/mailings/mailings_senders_test.exs
+++ b/test/keila/mailings/mailings_senders_test.exs
@@ -3,27 +3,50 @@ defmodule Keila.Mailings.SenderTest do
   alias Keila.Mailings
   alias Mailings.Sender
 
+  # Structurally valid but incorrect credentials
+  @smtp_params %{
+    "name" => "Sender",
+    "from_email" => "user@example.com",
+    "config" => %{
+      "type" => "smtp",
+      "smtp_username" => "user",
+      "smtp_password" => "password",
+      "smtp_relay" => "mail.example.com"
+    }
+  }
+
+  # Correct credentials
+  @test_params %{
+    "name" => "Sender 2",
+    "from_email" => "user2@example.com",
+    "config" => %{
+      "type" => "test"
+    }
+  }
+
   @tag :mailings
   test "Create senders" do
     group = insert!(:group)
     project = insert!(:project, group: group)
 
-    {:ok, %Sender{}} =
-      Mailings.create_sender(project.id, %{
-        "name" => "Sender",
-        "from_email" => "foo@bar.com",
-        "config" => %{
-          "type" => "smtp",
-          "smtp_username" => "foo",
-          "smtp_password" => "foo",
-          "smtp_relay" => "example.com"
-        }
-      })
+    {:ok, %Sender{}} = Mailings.create_sender(project.id, @smtp_params)
   end
 
   test "Delete senders" do
   end
 
   test "Update senders" do
+  end
+
+  @tag :mailings
+  test "Try credentials" do
+    group = insert!(:group)
+    project = insert!(:project, group: group)
+
+    {:ok, %Sender{id: sender_id}} = Mailings.create_sender(project.id, @smtp_params)
+    assert {:error, _} = Mailings.try_credentials(sender_id)
+
+    {:ok, %Sender{id: sender_id}} = Mailings.create_sender(project.id, @test_params)
+    assert {:ok, _} = Mailings.try_credentials(sender_id)
   end
 end


### PR DESCRIPTION
This PR introduces `Mailings.try_credentials/1` which will attempt to send a test email with the provided sender credentials.

It’s currently integrated into the UI so that users receive a warning when sending the email failed but the config is still saved:
![Screenshot_2021-04-26 Senders · Keila](https://user-images.githubusercontent.com/7488303/116081594-bcf0bc80-a69a-11eb-90cd-9092afbad458.png)

