### PR TITLE
Load all default values of the default template from CSS

### DIFF
--- a/lib/keila/templates/css.ex
+++ b/lib/keila/templates/css.ex
@@ -143,6 +143,21 @@ defmodule Keila.Templates.Css do
       {scope <> " " <> selector, property_list}
     end)
   end
+
+  @doc """
+  Returns the value of the given `property` for the given `selector`in the
+  provided  `styles`. Returns `nil` if the property could not be cound.
+  """
+  @spec get_value(t(), String.t(), String.t()) :: String.t() | nil
+  def get_value(styles, selector, property) do
+    case Enum.find(styles, &(elem(&1, 0) == selector)) do
+      {_selector, property_list} ->
+        Enum.find_value(property_list, &if(elem(&1, 0) == property, do: elem(&1, 1)))
+
+      nil ->
+        nil
+    end
+  end
 end
 
 defmodule Keila.Templates.Css.Parser do

--- a/lib/keila/templates/default_template.ex
+++ b/lib/keila/templates/default_template.ex
@@ -9,209 +9,77 @@ defmodule Keila.Templates.DefaultTemplate do
 
   @html_body File.read!("priv/email_templates/default.html.liquid") |> Solid.parse!()
   @styles File.read!("priv/email_templates/default.css") |> Css.parse!()
+
+  get_styles = fn selector, properties ->
+    Enum.map(properties, fn property ->
+      value = Css.get_value(@styles, selector, property)
+      %{selector: selector, property: property, default: value}
+    end)
+  end
+
   @style_template [
     {gettext("Layout"),
-     [
-       %{
-         selector: "body, #center-wrapper, #table-wrapper",
-         property: "background-color",
-         default: "#f3f4f6"
-       },
-       %{
-         selector: "body, #center-wrapper, #table-wrapper",
-         property: "font-family",
-         default: "Verdana, sans-serif"
-       }
-     ]},
+     get_styles.("body, #center-wrapper, #table-wrapper", [
+       "background-color",
+       "font-family"
+     ])},
     {gettext("Content"),
-     [
-       %{
-         selector: "#content",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "#content",
-         property: "background-color",
-         default: "#ffffff"
-       },
-       %{
-         selector: "#content",
-         property: "color",
-         default: "#1f2937"
-       }
-     ]},
+     get_styles.("#content", [
+       "color",
+       "background-color",
+       "font-family"
+     ])},
     {gettext("Heading 1"),
-     [
-       %{
-         selector: "h1",
-         property: "color",
-         default: "#4b5563"
-       },
-       %{
-         selector: "h1",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "h1",
-         property: "font-style",
-         default: "normal"
-       },
-       %{
-         selector: "h1",
-         property: "font-weight",
-         default: "bold"
-       },
-       %{
-         selector: "h1",
-         property: "text-decoration",
-         default: "none"
-       }
-     ]},
+     get_styles.("h1", [
+       "color",
+       "font-family",
+       "font-style",
+       "font-weight",
+       "text-decoration"
+     ])},
     {gettext("Heading 2"),
-     [
-       %{
-         selector: "h2",
-         property: "color",
-         default: "#4b5563"
-       },
-       %{
-         selector: "h2",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "h2",
-         property: "font-style",
-         default: "normal"
-       },
-       %{
-         selector: "h2",
-         property: "font-weight",
-         default: "bold"
-       },
-       %{
-         selector: "h2",
-         property: "text-decoration",
-         default: "none"
-       }
-     ]},
+     get_styles.("h2", [
+       "color",
+       "font-family",
+       "font-style",
+       "font-weight",
+       "text-decoration"
+     ])},
     {gettext("Heading 3"),
-     [
-       %{
-         selector: "h3",
-         property: "color",
-         default: "#4b5563"
-       },
-       %{
-         selector: "h3",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "h3",
-         property: "font-style",
-         default: "normal"
-       },
-       %{
-         selector: "h3",
-         property: "font-weight",
-         default: "bold"
-       },
-       %{
-         selector: "h3",
-         property: "text-decoration",
-         default: "none"
-       }
-     ]},
+     get_styles.("h3", [
+       "color",
+       "font-family",
+       "font-style",
+       "font-weight",
+       "text-decoration"
+     ])},
     {gettext("Links"),
-     [
-       %{
-         selector: "a",
-         property: "color",
-         default: "#1d4ed8"
-       },
-       %{
-         selector: "h4 a",
-         property: "text-decoration",
-         default: "underline"
-       }
-     ]},
+     get_styles.("a", [
+       "color",
+       "text-decoration"
+     ])},
     {gettext("Button"),
-     [
-       %{
-         selector: "h4 a",
-         property: "background-color",
-         default: "#1d4ed8"
-       },
-       %{
-         selector: "h4 a",
-         property: "color",
-         default: "#ffffff"
-       },
-       %{
-         selector: "h4 a",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "h4 a",
-         property: "font-style",
-         default: "normal"
-       },
-       %{
-         selector: "h4 a",
-         property: "font-weight",
-         default: "bold"
-       },
-       %{
-         selector: "h4 a",
-         property: "text-decoration",
-         default: "none"
-       }
-     ]},
+     get_styles.("h4 > a", [
+       "color",
+       "background-color",
+       "font-family",
+       "font-style",
+       "font-weight",
+       "text-decoration"
+     ])},
     {gettext("Signature"),
-     [
-       %{
-         selector: "#signature td",
-         property: "color",
-         default: "#4b5563"
-       },
-       %{
-         selector: "#signature td",
-         property: "font-family",
-         default: "inherit"
-       },
-       %{
-         selector: "#signature td",
-         property: "font-style",
-         default: "normal"
-       },
-       %{
-         selector: "#signature td",
-         property: "font-weight",
-         default: "bold"
-       },
-       %{
-         selector: "#signature td",
-         property: "text-decoration",
-         default: "none"
-       }
-     ]},
+     get_styles.("#signature td", [
+       "color",
+       "font-family",
+       "font-style",
+       "font-weight",
+       "text-decoration"
+     ])},
     {gettext("Signature links"),
-     [
-       %{
-         selector: "#signature td a",
-         property: "color",
-         default: "#374151"
-       },
-       %{
-         selector: "#signature td a",
-         property: "text-decoration",
-         default: "underline"
-       }
-     ]}
+     get_styles.("#signature td a", [
+       "color",
+       "text-decoration"
+     ])}
   ]
 
   @spec styles() :: Keila.Templates.Css.t()

--- a/priv/email_templates/default.css
+++ b/priv/email_templates/default.css
@@ -1,5 +1,10 @@
 h1 {
     margin: 0 0 20px 0;
+    color: #4b5563;
+    font-family: inherit;
+    font-style: normal;
+    font-weight: bold;
+    text-decoration: none;
 }
 
 h2 {
@@ -24,14 +29,45 @@ h4 {
     margin: 20px 0;
 }
 
+a {
+    color: #1d4ed8;
+    text-decoration: underline;
+}
+
 h4 > a {
+    color: #ffffff;
+    background-color: #1d4ed8;
     padding: 10px;
     display: block;
     cursor: pointer;
     text-align: center;
 }
 
+body, #center-wrapper, #table-wrapper {
+    background-color: #f3f4f6;
+    font-family: Verdana, sans-serif;
+}
+
+#content {
+    font-family: inherit;
+    background-color: #ffffff;
+    color: #1f2937;
+}
+
 #content img {
     width: 100%;
     max-width: 600px;
+}
+
+#signature td {
+    color: #4b5563;
+    font-family: inherit;
+    font-style: normal;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+#signature td a {
+    color: #374151;
+    text-decoration: underline;
 }

--- a/test/keila/templates/templates_test.exs
+++ b/test/keila/templates/templates_test.exs
@@ -49,6 +49,12 @@ defmodule Keila.TemplatesTest do
   end
 
   @tag :templates
+  test "get CSS values by selector and property" do
+    css = Css.parse!(@input_css)
+    assert "#f0f" == Css.get_value(css, ".foo", "background-color")
+  end
+
+  @tag :templates
   test "create template", %{project: project} do
     params = params(:template)
     assert {:ok, %Template{}} = Templates.create_template(project.id, params)


### PR DESCRIPTION
This fixes a small issue in which there would be discrepancy between an unmodified custom template and the "Default Template" option in the campaign editor.