### PR TITLE
Feature/upsert on import

### DIFF
--- a/lib/keila/contacts/import.ex
+++ b/lib/keila/contacts/import.ex
@@ -50,11 +50,12 @@ defmodule Keila.Contacts.Import do
     lines = read_file_line_count!(filename)
     send(notify_pid, {:contacts_import_progress, 0, lines})
 
-    insert_ops = [returning: false, conflict_target: [:email, :project_id]] ++
-      case on_conflicts do
-        :replace -> [on_conflict: {:replace_all_except, [:id, :email, :project_id]}]
-        :ignore -> [on_conflict: :nothing]
-      end
+    insert_ops =
+      [returning: false, conflict_target: [:email, :project_id]] ++
+        case on_conflicts do
+          :replace -> [on_conflict: {:replace_all_except, [:id, :email, :project_id]}]
+          :ignore -> [on_conflict: :nothing]
+        end
 
     File.stream!(filename)
     |> parser.parse_stream()

--- a/lib/keila/contacts/import.ex
+++ b/lib/keila/contacts/import.ex
@@ -12,6 +12,15 @@ defmodule Keila.Contacts.Import do
   import KeilaWeb.Gettext
   alias Keila.Contacts.{Contact, ImportError}
 
+  @doc """
+  Imports csv file and create new `Contacts` on database.
+
+  ## Options
+    - `:notify` - pid used to send messages about upload progress
+    - `:on_conflict`:
+      - `:replace`: replace contacts that have the same email address to the latest information on the CSV (or already on database)
+      - `:ignore`: ignore contacts that already exists on database and will do nothing
+  """
   @spec import_csv(Keila.Projects.Project.id(), String.t(), Keyword.t()) ::
           :ok | {:error, String.t()}
   def import_csv(project_id, filename, opts) do

--- a/lib/keila_web/live/contact_import_live.ex
+++ b/lib/keila_web/live/contact_import_live.ex
@@ -19,11 +19,12 @@ defmodule KeilaWeb.ContactImportLive do
   end
 
   @impl true
-  def handle_event("validate", _params, socket) do
-    {:noreply, socket}
+  def handle_event("validate", %{"import" => import_options}, socket) do
+    {:noreply, assign(socket, :import_replace, import_options["replace"] == "true")}
   end
 
-  def handle_event("import", _params, socket) do
+  def handle_event("import", %{"import" => import_options}, socket) do
+    # IO.inspect(params)
     [{csv_filename, import_task}] =
       consume_uploaded_entries(socket, :csv, fn %{path: upload_path}, _entry ->
         pid = self()
@@ -35,9 +36,14 @@ defmodule KeilaWeb.ContactImportLive do
         csv_filename = Path.join(System.tmp_dir!(), csv_basename)
         File.cp!(upload_path, csv_filename)
 
+        on_conflict = if import_options["replace"] == "true", do: :replace, else: :ignore
+
         task =
           Task.async(fn ->
-            Keila.Contacts.import_csv(socket.assigns.current_project.id, csv_filename, notify: pid)
+            Keila.Contacts.import_csv(socket.assigns.current_project.id, csv_filename,
+              notify: pid,
+              on_conflict: on_conflict
+            )
           end)
 
         {csv_filename, task}
@@ -64,7 +70,6 @@ defmodule KeilaWeb.ContactImportLive do
 
   def handle_info({reference, {:error, reason}}, socket) when is_reference(reference) do
     File.rm(socket.assigns.csv_filename)
-
     {:noreply, assign(socket, :import_error, reason)}
   end
 
@@ -93,5 +98,6 @@ defmodule KeilaWeb.ContactImportLive do
     |> assign(:import_progress, 0)
     |> assign(:import_total, 0)
     |> assign(:import_error, nil)
+    |> assign(:import_replace, true)
   end
 end

--- a/lib/keila_web/live/contact_import_live.ex
+++ b/lib/keila_web/live/contact_import_live.ex
@@ -24,7 +24,6 @@ defmodule KeilaWeb.ContactImportLive do
   end
 
   def handle_event("import", %{"import" => import_options}, socket) do
-    # IO.inspect(params)
     [{csv_filename, import_task}] =
       consume_uploaded_entries(socket, :csv, fn %{path: upload_path}, _entry ->
         pid = self()

--- a/lib/keila_web/templates/contact/import_live.html.heex
+++ b/lib/keila_web/templates/contact/import_live.html.heex
@@ -14,7 +14,7 @@
 
     <%= cond do %>
     <% @import_total == 0 -> %>
-        <form id="import-form" phx-submit="import" phx-change="validate" class="flex flex-col items-start gap-4">
+        <.form let={f} for={:import} id="import-form" phx-submit="import" phx-change="validate" class="flex flex-col items-start gap-4">
             <% class = "button #{ if Enum.empty?(@uploads.csv.entries), do: "button--cta button--large" }" %>
             <label class={class}>
                 <%= render_icon(:upload) %>
@@ -25,14 +25,18 @@
                 <% end %>
             </label>
 
-
             <%= if not Enum.empty?(@uploads.csv.entries) do %>
                 <button class="button button--cta button--large" type="submit">
                     <%= render_icon(:cursor_click) %>
                     <%= gettext("Start Import") %>
                 </button>
             <% end %>
-        </form>
+
+            <div class="form-row">
+                <%= label(f, :replace, "Replace duplicates?") %>
+                <%= checkbox(f, :replace, checked: @import_replace) %>
+            </div>
+        </.form>
 
     <% @import_total > @import_progress -> %>
         <h2 class="text-xl sm:text-3xl">Importing Contacts (<%= @import_progress %> / <%= @import_total %>) …</h2>

--- a/test/keila/contacts/contacts_test.exs
+++ b/test/keila/contacts/contacts_test.exs
@@ -119,44 +119,58 @@ defmodule Keila.ContactsTest do
 
   @tag :contacts
   test "Import RFC 4180 CSV with on_conflict: replace (upsert)", %{project: project} do
-    assert :ok == Contacts.import_csv(project.id, "test/keila/contacts/import_rfc_4180_upsert.csv", on_conflict: :replace)
+    assert :ok ==
+             Contacts.import_csv(project.id, "test/keila/contacts/import_rfc_4180_upsert.csv",
+               on_conflict: :replace
+             )
+
     contacts = Contacts.get_project_contacts(project.id)
 
-    expected = [%{first_name: "João", last_name: "Nilton"}, %{first_name: "Elisa", last_name: "Paula"},
-                %{first_name: "Foo", last_name: "Bar"}]
+    expected = [
+      %{first_name: "João", last_name: "Nilton"},
+      %{first_name: "Elisa", last_name: "Paula"},
+      %{first_name: "Foo", last_name: "Bar"}
+    ]
 
     for %{first_name: e_fn, last_name: e_ln} <- expected do
       assert Enum.find(contacts, fn
-        %{first_name: ^e_fn, last_name: ^e_ln} -> true
-        _ -> false
-      end)
+               %{first_name: ^e_fn, last_name: ^e_ln} -> true
+               _ -> false
+             end)
     end
 
     refute Enum.find(contacts, fn
-      %{first_name: "João", last_name: "Milton"} -> true
-      _ -> false
-    end)
+             %{first_name: "João", last_name: "Milton"} -> true
+             _ -> false
+           end)
   end
 
   @tag :contacts
   test "Import RFC 4180 CSV with on_conflict: ignore", %{project: project} do
-    assert :ok == Contacts.import_csv(project.id, "test/keila/contacts/import_rfc_4180_upsert.csv", on_conflict: :ignore)
+    assert :ok ==
+             Contacts.import_csv(project.id, "test/keila/contacts/import_rfc_4180_upsert.csv",
+               on_conflict: :ignore
+             )
+
     contacts = Contacts.get_project_contacts(project.id)
 
-    expected = [%{first_name: "João", last_name: "Milton"}, %{first_name: "Elisa", last_name: "Paula"},
-                %{first_name: "Foo", last_name: "Bar"}]
+    expected = [
+      %{first_name: "João", last_name: "Milton"},
+      %{first_name: "Elisa", last_name: "Paula"},
+      %{first_name: "Foo", last_name: "Bar"}
+    ]
 
     for %{first_name: e_fn, last_name: e_ln} <- expected do
       assert Enum.find(contacts, fn
-        %{first_name: ^e_fn, last_name: ^e_ln} -> true
-        _ -> false
-      end)
+               %{first_name: ^e_fn, last_name: ^e_ln} -> true
+               _ -> false
+             end)
     end
 
     refute Enum.find(contacts, fn
-      %{first_name: "João", last_name: "Nilton"} -> true
-      _ -> false
-    end)
+             %{first_name: "João", last_name: "Nilton"} -> true
+             _ -> false
+           end)
   end
 
   @tag :contacts

--- a/test/keila/contacts/import_rfc_4180_upsert.csv
+++ b/test/keila/contacts/import_rfc_4180_upsert.csv
@@ -1,0 +1,6 @@
+Email,First name,Last name
+joao@example.com,João,Milton
+elisa@example.com,Elisa,Paula
+foo-1@example.com,Foo,Bar
+foo-2@example.com,Foo,Bar
+joao@example.com,João,Nilton


### PR DESCRIPTION
Implements the import feature described at #87.

- now on `Keila.Contacts.import_csv` there's an extra parameter called `:on_conflict` that can either be `:replace` or `:ignore`
- if set to `:replace`, duplicated contacts (as detected by the e-mail) will be replaced with the latest ones found in the import file
- if set to `:ignore`, duplicated contacts found will always be skipped
- on the UI there's now a checkbox that controls this behavior and is set by default to replace