### PR TITLE
added fix for style glitch in campaign settings Fixes #117

### DIFF
--- a/lib/keila_web/templates/campaign/_settings_dialog.html.heex
+++ b/lib/keila_web/templates/campaign/_settings_dialog.html.heex
@@ -41,7 +41,7 @@
                         <%= with_validation(f, :sender_id) do %>
                             <%= select(f, :sender_id,
                                 (if input_value(f, :sender_id) == nil, do: [{gettext("Please select a sender"), nil}], else: []) ++ Enum.map(@senders, &{"#{&1.name} (#{&1.from_name} <#{&1.from_email}>)", &1.id}),
-                                class: "text-black sm:w-full")
+                                class: "text-black w-full")
                             %>
                         <% end %>
                     <% else %>

--- a/lib/keila_web/templates/campaign/_settings_dialog.html.heex
+++ b/lib/keila_web/templates/campaign/_settings_dialog.html.heex
@@ -41,7 +41,7 @@
                         <%= with_validation(f, :sender_id) do %>
                             <%= select(f, :sender_id,
                                 (if input_value(f, :sender_id) == nil, do: [{gettext("Please select a sender"), nil}], else: []) ++ Enum.map(@senders, &{"#{&1.name} (#{&1.from_name} <#{&1.from_email}>)", &1.id}),
-                                class: "text-black")
+                                class: "text-black sm:w-full")
                             %>
                         <% end %>
                     <% else %>


### PR DESCRIPTION
Fix for style glitch in campaign settings 
Changed the files in :
lib/keila_web/templates/campaign/_settings_dialog.html.heex
and added sm:w-full class to the select element at line 45.
Before:

![image](https://user-images.githubusercontent.com/53145662/155966655-1583fd92-c7e2-461b-933f-38bdb78ae640.png)

After:

![image](https://user-images.githubusercontent.com/53145662/155967386-070061fe-edfb-4c62-94d7-6dbc2dd1e957.png)

