### PR TITLE
Add do-not-track option for campaigns

### DIFF
--- a/lib/keila/mailings/builder.ex
+++ b/lib/keila/mailings/builder.ex
@@ -228,7 +228,7 @@ defmodule Keila.Mailings.Builder do
 
   # TODO add campaign settings for disabling/configuring tracking
   defp maybe_put_tracking(email, campaign, recipient) do
-    if email.html_body && recipient do
+    if email.html_body && recipient && !campaign.settings.do_not_track do
       put_tracking(email, campaign, recipient)
     else
       email

--- a/lib/keila/mailings/schemas/campaign_settings.ex
+++ b/lib/keila/mailings/schemas/campaign_settings.ex
@@ -5,10 +5,11 @@ defmodule Keila.Mailings.Campaign.Settings do
   embedded_schema do
     field(:type, Ecto.Enum, values: [:text, :markdown])
     field(:enable_wysiwyg, :boolean, default: true)
+    field(:do_not_track, :boolean, default: false)
   end
 
   def changeset(struct \\ %__MODULE__{}, params) do
     struct
-    |> cast(params, [:type, :enable_wysiwyg])
+    |> cast(params, [:type, :enable_wysiwyg, :do_not_track])
   end
 end

--- a/lib/keila_web/templates/campaign/_settings_dialog.html.heex
+++ b/lib/keila_web/templates/campaign/_settings_dialog.html.heex
@@ -89,6 +89,13 @@
                     <% end %>
                 </div>
 
+                <div class="form-row-checkbox">
+                    <%= inputs_for(f, :settings, fn fs -> %>
+                        <%= checkbox(fs, :do_not_track, checked_value: "false", unchecked_value: "true") %>
+                        <%= label(fs, :do_not_track, gettext("Enable click/open tracking")) %>
+                    <% end) %>
+                </div>
+
                 <div class="form-row md:col-span-full">
                     <%= label(f, :segment_id, gettext("Campaign data")) %>
                     <span class="block text-sm mb-2"><%= gettext("You can add any JSON object as custom data to your campaign.") %></span>

--- a/lib/keila_web/templates/campaign/new.html.heex
+++ b/lib/keila_web/templates/campaign/new.html.heex
@@ -53,46 +53,53 @@
             <% end %>
         </div>
 
-            <div class="form-row">
+        <div class="form-row-checkbox">
+            <%= inputs_for(f, :settings, fn fs -> %>
+                <%= checkbox(fs, :do_not_track, checked_value: "false", unchecked_value: "true") %>
+                <%= label(fs, :do_not_track, gettext("Enable click/open tracking")) %>
+            <% end) %>
+        </div>
+
+        <div class="form-row">
+            <%= inputs_for(f, :settings, fn fs -> %>
+                <%= label(fs, :type, gettext("Campaign Type")) %>
+                <%= select(fs, :type, [
+                    {gettext("Markdown"), "markdown"},
+                    {gettext("Text only"), "text"}
+                ], [x_model: "type"]) %>
+            <% end) %>
+        </div>
+
+        <template x-if="type === 'markdown'">
+            <div class="form-row-checkbox">
                 <%= inputs_for(f, :settings, fn fs -> %>
-                    <%= label(fs, :type, gettext("Campaign Type")) %>
-                    <%= select(fs, :type, [
-                        {gettext("Markdown"), "markdown"},
-                        {gettext("Text only"), "text"}
-                    ], [x_model: "type"]) %>
+                    <%= checkbox(fs, :enable_wysiwyg) %>
+                    <%= label(fs, :enable_wysiwyg, gettext("Enable rich text editor")) %>
                 <% end) %>
             </div>
+        </template>
+        <template x-if="type === 'markdown'">
+            <div class="form-row">
+                <%= label(f, :template_id, gettext("Template")) %>
 
-            <template x-if="type === 'markdown'">
-                <div class="form-row-checkbox">
-                    <%= inputs_for(f, :settings, fn fs -> %>
-                        <%= checkbox(fs, :enable_wysiwyg) %>
-                        <%= label(fs, :enable_wysiwyg, gettext("Enable rich text editor")) %>
-                    <% end) %>
-                </div>
-            </template>
-            <template x-if="type === 'markdown'">
-                <div class="form-row">
-                    <%= label(f, :template_id, gettext("Template")) %>
-
-                    <%= with_validation(f, :template_id) do %>
-                        <%= select(f, :template_id, [{gettext("Default"), nil} | Enum.map(@templates, &{&1.name, &1.id})], class: "text-black") %>
-                    <% end %>
-                </div>
-            </template>
-
-            <div class="form-row md:col-span-full">
-                <%= label(f, :segment_id, gettext("Campaign data")) %>
-                <span class="block text-sm mb-2"><%= gettext("You can add any JSON object as custom data to your campaign.") %></span>
-                <%= with_validation(f, :data) do %>
-                    <%= case input_value(f, :data) do %>
-                    <% data when is_map(data) -> %>
-                        <%= textarea(f, :data, value: Jason.encode!(data), class: "text-white bg-gray-900", rows: 5) %>
-                    <% _other ->  %>
-                        <%= textarea(f, :data, class: "text-white bg-gray-900", rows: 5) %>
-                    <% end %>
+                <%= with_validation(f, :template_id) do %>
+                    <%= select(f, :template_id, [{gettext("Default"), nil} | Enum.map(@templates, &{&1.name, &1.id})], class: "text-black") %>
                 <% end %>
             </div>
+        </template>
+
+        <div class="form-row md:col-span-full">
+            <%= label(f, :segment_id, gettext("Campaign data")) %>
+            <span class="block text-sm mb-2"><%= gettext("You can add any JSON object as custom data to your campaign.") %></span>
+            <%= with_validation(f, :data) do %>
+                <%= case input_value(f, :data) do %>
+                <% data when is_map(data) -> %>
+                    <%= textarea(f, :data, value: Jason.encode!(data), class: "text-white bg-gray-900", rows: 5) %>
+                <% _other ->  %>
+                    <%= textarea(f, :data, class: "text-white bg-gray-900", rows: 5) %>
+                <% end %>
+            <% end %>
+        </div>
 
         <div class="flex">
             <button class="button button--cta button--large">

--- a/lib/keila_web/templates/campaign/stats_live.html.heex
+++ b/lib/keila_web/templates/campaign/stats_live.html.heex
@@ -113,7 +113,7 @@
     <% end %>
 </div>
 
-<%= if @stats.sent_count > 0 do %>
+<%= if @stats.sent_count > 0 && !@campaign.settings.do_not_track do %>
     <div class="container mt-8">
         <h3 class="font-light text-2xl"><%= gettext("Statistics") %></h3>
         <%= gettext(
@@ -150,5 +150,17 @@
                 </tr>
             <% end %>
         </table>
+    </div>
+<% end %>
+
+<%= if @stats.sent_count > 0 && @campaign.settings.do_not_track do %>
+    <div class="container mt-8">
+        <div class="flex gap-4 items-center py-4 sm:py-8">
+            <span class="inline-flex h-12 w-12"><%= render_icon(:eye_off) %></span>
+            <div class="max-w-xl">
+                <h3 class="font-light text-2xl"><%= gettext("Do-not-track Campaign") %></h3>
+                <%= gettext("You have chosen not to track clicks and opens for this campaign. Thanks for respecting the privacy of your recipients!", count: @stats.sent_count) %>
+            </div>
+        </div>
     </div>
 <% end %>

--- a/test/keila/mailings/mailings_builder_test.exs
+++ b/test/keila/mailings/mailings_builder_test.exs
@@ -64,6 +64,39 @@ defmodule Keila.Mailings.BuilderTest do
   end
 
   @tag :mailings_builder
+  test "Tracking can be enabled or disabled at the campaign-level" do
+    project = insert!(:project)
+    contact = insert!(:contact, project_id: project.id)
+    recipient = insert!(:mailings_recipient, contact: contact, project_id: project.id)
+    sender = build(:mailings_sender)
+
+    campaign =
+      insert!(:mailings_campaign,
+        project_id: project.id,
+        subject: "My Campaign",
+        sender: sender,
+        text_body: """
+        [Link](https://maybe-track.example.com)
+        """,
+        settings: %Mailings.Campaign.Settings{
+          type: :markdown
+        }
+      )
+
+    email = %Swoosh.Email{} = Mailings.Builder.build(campaign, recipient, %{})
+    {:ok, document} = Floki.parse_document(email.html_body)
+    # When tracking is enabled, the original link is not present
+    assert "https://maybe-track.example.com" not in Floki.attribute(document, "a", "href")
+
+    campaign =
+      Map.update!(campaign, :settings, fn settings -> %{settings | do_not_track: true} end)
+
+    email = %Swoosh.Email{} = Mailings.Builder.build(campaign, recipient, %{})
+    {:ok, document} = Floki.parse_document(email.html_body)
+    assert "https://maybe-track.example.com" in Floki.attribute(document, "a", "href")
+  end
+
+  @tag :mailings_builder
   test "Adds X-Keila-Invalid header when there is an error" do
     contact = build(:contact, id: Keila.Contacts.Contact.Id.cast(0) |> elem(1))
     sender = build(:mailings_sender)


### PR DESCRIPTION
This PR implements #151 and allows disabling tracking at the campaign-level. It doesn't include a default setting at the project level - but since there aren't any default settings for anything at the project level right now, this should be addressed at a later point.
![do-not-track](https://user-images.githubusercontent.com/7488303/190249811-41eda496-84d3-4da6-a44e-71801a064c45.png)
