### PR TITLE
Adding User-Agent filtering

### DIFF
--- a/lib/keila/tracking/tracking.ex
+++ b/lib/keila/tracking/tracking.ex
@@ -156,10 +156,17 @@ defmodule Keila.Tracking do
     end
   end
 
-  def track(:open, %{encoded_url: encoded_url, recipient_id: recipient_id, hmac: hmac}) do
+  def track(:open, %{
+        encoded_url: encoded_url,
+        recipient_id: recipient_id,
+        hmac: hmac,
+        user_agent: user_agent
+      }) do
     case verify_hmac(hmac, encoded_url, recipient_id) do
       :ok ->
-        set_recipient_opened_at(recipient_id)
+        unless is_user_agent_bot(user_agent) do
+          set_recipient_opened_at(recipient_id)
+        end
 
         {:ok, URI.decode_www_form(encoded_url)}
 
@@ -242,4 +249,9 @@ defmodule Keila.Tracking do
 
   defp hmac_key,
     do: Application.get_env(:keila, KeilaWeb.Endpoint) |> Keyword.get(:secret_key_base)
+
+  @bot_user_agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0"
+  defp is_user_agent_bot(user_agent) do
+    user_agent == @bot_user_agent
+  end
 end

--- a/lib/keila/tracking/tracking.ex
+++ b/lib/keila/tracking/tracking.ex
@@ -126,13 +126,12 @@ defmodule Keila.Tracking do
   Tracks an event.
 
   ## `:open` event
-  - Required params: `:encoded_url`, `:recipient_id`, `hmac`
-  - Optional params: `link_id`
+  - Required params: `:encoded_url`, `:recipient_id`, `:hmac`, `:user_agent`
 
   Returns: `{:ok, url}` if  hmac verification was successful, otherwise `:error`.
 
   ## `:click` event
-  - Required params: `:encoded_url`, `:recipient_id`, `hmac`
+  - Required params: `:encoded_url`, `:recipient_id`, `:hmac`
   - Optional params: `link_id`
 
   Returns: `{:ok, url}` if  hmac verification was successful, otherwise `:error`.

--- a/lib/keila_web/controllers/tracking_controller.ex
+++ b/lib/keila_web/controllers/tracking_controller.ex
@@ -10,7 +10,8 @@ defmodule KeilaWeb.TrackingController do
     case Keila.Tracking.track(:open, %{
            encoded_url: encoded_url,
            recipient_id: recipient_id,
-           hmac: hmac
+           hmac: hmac,
+           user_agent: get_req_header(conn, "user-agent")
          }) do
       {:ok, url} -> redirect(conn, external: url)
       :error -> put_status(conn, 404) |> halt()

--- a/lib/keila_web/controllers/tracking_controller.ex
+++ b/lib/keila_web/controllers/tracking_controller.ex
@@ -11,7 +11,7 @@ defmodule KeilaWeb.TrackingController do
            encoded_url: encoded_url,
            recipient_id: recipient_id,
            hmac: hmac,
-           user_agent: get_req_header(conn, "user-agent")
+           user_agent: get_req_header(conn, "user-agent") |> List.first()
          }) do
       {:ok, url} -> redirect(conn, external: url)
       :error -> put_status(conn, 404) |> halt()

--- a/test/keila_web/controllers/tracking_controller_test.exs
+++ b/test/keila_web/controllers/tracking_controller_test.exs
@@ -21,11 +21,48 @@ defmodule KeilaWeb.TrackingControllerTest do
         url: @url
       })
 
-    conn = get(conn, path)
+    conn =
+      build_conn()
+      |> put_req_header(
+        "user-agent",
+        "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0"
+      )
+      |> get(path)
+
     assert conn.status == 302
 
     updated_recipient = Keila.Repo.get(Keila.Mailings.Recipient, recipient.id)
     assert not is_nil(updated_recipient.opened_at)
+    assert is_nil(updated_recipient.clicked_at)
+  end
+
+  test "dont track open if user-agent is considered a bot", %{conn: conn} do
+    campaign = insert!(:mailings_campaign)
+    recipient = insert!(:mailings_recipient, campaign: campaign)
+
+    assert link = %Link{} = Tracking.register_link(@url, campaign.id)
+    assert link == Tracking.get_or_register_link(@url, campaign.id)
+    assert link.url == @url
+
+    path =
+      Tracking.get_tracking_path(conn, :open, %{
+        campaign_id: campaign.id,
+        recipient_id: recipient.id,
+        url: @url
+      })
+
+    conn =
+      build_conn()
+      |> put_req_header(
+        "user-agent",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0"
+      )
+      |> get(path)
+
+    assert conn.status == 302
+
+    updated_recipient = Keila.Repo.get(Keila.Mailings.Recipient, recipient.id)
+    assert is_nil(updated_recipient.opened_at)
     assert is_nil(updated_recipient.clicked_at)
   end
 


### PR DESCRIPTION
Adds User-Agent filtering to open links accordingly to this [blog post](https://www.gmass.co/blog/false-opens-in-gmail/).

I used the follow User-agent for the filter:
`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0`

@wmnnd, I'm creating the PR before completing the tests so you can take a look beforehand :smile: 

Please let me know what you think.