### PR TITLE
Ordering Segments Alphabetically

### DIFF
--- a/lib/keila/contacts/contacts.ex
+++ b/lib/keila/contacts/contacts.ex
@@ -413,7 +413,7 @@ defmodule Keila.Contacts do
   """
   @spec get_project_segments(Project.id()) :: [Segment.t()] | []
   def get_project_segments(project_id) when is_id(project_id) do
-    from(s in Segment, where: s.project_id == ^project_id)
+    from(s in Segment, where: s.project_id == ^project_id, order_by: s.name)
     |> Repo.all()
   end
 end

--- a/test/keila/contacts/contacts_segments_test.exs
+++ b/test/keila/contacts/contacts_segments_test.exs
@@ -25,13 +25,15 @@ defmodule Keila.ContactsSegmentsTest do
 
   @tag :contacts_segments
   test "List project segments", %{project: project} do
-    segment1 = insert!(:contacts_segment, %{project_id: project.id})
-    segment2 = insert!(:contacts_segment, %{project_id: project.id})
+    segment1 = insert!(:contacts_segment, %{project_id: project.id, name: "Z segment"})
+    segment2 = insert!(:contacts_segment, %{project_id: project.id, name: "A segment"})
     _segment3 = insert!(:contacts_segment)
 
     assert segments = [%Segment{}, %Segment{}] = Contacts.get_project_segments(project.id)
     assert segment1 in segments
     assert segment2 in segments
+    assert segment1 == Enum.at(segments, 1)
+    assert segment2 == Enum.at(segments, 0)
   end
 
   @tag :contacts_segments


### PR DESCRIPTION
This PR changes the query that gets all segments and order results alphabetically using Ecto.

<img width="1443" alt="image" src="https://github.com/pentacent/keila/assets/2154092/bc9e0254-fe75-4252-8e5e-014e5ba8b099">
