### PR TITLE
Add contacts CSV export capability

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@
 import Config
 
 config :keila,
-  ecto_repos: [Keila.Repo]
+  ecto_repos: [Keila.Repo],
+  csv_export_chunk_size: 100
 
 # Configures the endpoint
 config :keila, KeilaWeb.Endpoint,

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,9 +7,9 @@
 # General application configuration
 import Config
 
-config :keila,
-  ecto_repos: [Keila.Repo],
-  csv_export_chunk_size: 100
+config :keila, ecto_repos: [Keila.Repo]
+
+config :keila, KeilaWeb.ContactsCsvExport, chunk_size: 100
 
 # Configures the endpoint
 config :keila, KeilaWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,9 @@ config :keila, Keila.Repo,
   timeout: 60_000,
   pool_size: 16
 
-config :keila, skip_migrations: true, csv_export_chunk_size: 3
+config :keila, skip_migrations: true
+
+config :keila, KeilaWeb.ContactsCsvExport, chunk_size: 3
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,7 @@ config :keila, Keila.Repo,
   timeout: 60_000,
   pool_size: 16
 
-config :keila, skip_migrations: true
+config :keila, skip_migrations: true, csv_export_chunk_size: 3
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/lib/keila_web/controllers/contact_controller.ex
+++ b/lib/keila_web/controllers/contact_controller.ex
@@ -4,16 +4,21 @@ defmodule KeilaWeb.ContactController do
   import Ecto.Changeset
   alias Keila.Contacts
 
-  plug :authorize
-       when action not in [
-              :index,
-              :index_unsubscribed,
-              :index_unreachable,
-              :new,
-              :post_new,
-              :delete,
-              :import
-            ]
+  plug(
+    :authorize
+    when action not in [
+           :index,
+           :index_unsubscribed,
+           :index_unreachable,
+           :new,
+           :post_new,
+           :delete,
+           :import,
+           :export
+         ]
+  )
+
+  @csv_export_chunk_size Application.compile_env!(:keila, :csv_export_chunk_size)
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, params) do
@@ -150,6 +155,42 @@ defmodule KeilaWeb.ContactController do
     |> put_meta(:title, gettext("Edit Contact"))
     |> assign(:changeset, changeset)
     |> render("edit.html")
+  end
+
+  @spec export(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def export(conn, %{"project_id" => project_id}) do
+    filename = "contacts_#{project_id}.csv"
+
+    conn =
+      conn
+      |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
+      |> put_resp_header("content-type", "text/csv")
+      |> send_chunked(200)
+
+    header =
+      [["Email", "First name", "Last name", "Data"]]
+      |> NimbleCSV.RFC4180.dump_to_iodata()
+      |> IO.iodata_to_binary()
+
+    {:ok,conn} = chunk(conn, header)
+
+    Keila.Repo.transaction(fn ->
+      Contacts.stream_project_contacts(project_id, max_rows: @csv_export_chunk_size)
+      |> Stream.map(fn contact ->
+        data = if is_nil(contact.data), do: nil, else: Jason.encode!(contact.data)
+        [[contact.email, contact.first_name, contact.last_name, data]]
+        |> NimbleCSV.RFC4180.dump_to_iodata()
+        |> IO.iodata_to_binary()
+      end)
+      |> Stream.chunk_every(@csv_export_chunk_size)
+      |> Enum.reduce_while(conn, fn chunk, conn ->
+        case Plug.Conn.chunk(conn, chunk) do
+          {:ok, conn} -> {:cont, conn}
+          {:error, :closed} -> {:halt, conn}
+        end
+      end)
+    end)
+    |> then(fn {:ok, conn} -> conn end)
   end
 
   defp current_project(conn), do: conn.assigns.current_project

--- a/lib/keila_web/controllers/contact_controller.ex
+++ b/lib/keila_web/controllers/contact_controller.ex
@@ -168,7 +168,7 @@ defmodule KeilaWeb.ContactController do
       |> send_chunked(200)
 
     header =
-      [["Email", "First name", "Last name", "Data"]]
+      [["Email", "First name", "Last name", "Data", "Status"]]
       |> NimbleCSV.RFC4180.dump_to_iodata()
       |> IO.iodata_to_binary()
 
@@ -178,7 +178,7 @@ defmodule KeilaWeb.ContactController do
       Contacts.stream_project_contacts(project_id, max_rows: @csv_export_chunk_size)
       |> Stream.map(fn contact ->
         data = if is_nil(contact.data), do: nil, else: Jason.encode!(contact.data)
-        [[contact.email, contact.first_name, contact.last_name, data]]
+        [[contact.email, contact.first_name, contact.last_name, data, contact.status]]
         |> NimbleCSV.RFC4180.dump_to_iodata()
         |> IO.iodata_to_binary()
       end)

--- a/lib/keila_web/controllers/contact_controller.ex
+++ b/lib/keila_web/controllers/contact_controller.ex
@@ -172,12 +172,13 @@ defmodule KeilaWeb.ContactController do
       |> NimbleCSV.RFC4180.dump_to_iodata()
       |> IO.iodata_to_binary()
 
-    {:ok,conn} = chunk(conn, header)
+    {:ok, conn} = chunk(conn, header)
 
     Keila.Repo.transaction(fn ->
       Contacts.stream_project_contacts(project_id, max_rows: @csv_export_chunk_size)
       |> Stream.map(fn contact ->
         data = if is_nil(contact.data), do: nil, else: Jason.encode!(contact.data)
+
         [[contact.email, contact.first_name, contact.last_name, data, contact.status]]
         |> NimbleCSV.RFC4180.dump_to_iodata()
         |> IO.iodata_to_binary()

--- a/lib/keila_web/controllers/segment_controller.ex
+++ b/lib/keila_web/controllers/segment_controller.ex
@@ -4,8 +4,6 @@ defmodule KeilaWeb.SegmentController do
   import Ecto.Changeset
   import Phoenix.LiveView.Controller
 
-  @csv_export_chunk_size Application.compile_env!(:keila, :csv_export_chunk_size)
-
   plug(:authorize when action not in [:index, :new, :create, :delete])
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
@@ -77,42 +75,8 @@ defmodule KeilaWeb.SegmentController do
   def contacts_export(conn, %{"project_id" => project_id, "id" => segment_id}) do
     filename = "contacts_#{project_id}_segment_#{segment_id}.csv"
 
-    conn =
-      conn
-      |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
-      |> put_resp_header("content-type", "text/csv")
-      |> send_chunked(200)
-
-    header =
-      [["Email", "First name", "Last name", "Data", "Status"]]
-      |> NimbleCSV.RFC4180.dump_to_iodata()
-      |> IO.iodata_to_binary()
-
-    {:ok, conn} = chunk(conn, header)
-
-    args = [
-      max_rows: @csv_export_chunk_size,
-      filter: conn.assigns.segment.filter || %{}
-    ]
-
-    Keila.Repo.transaction(fn ->
-      Contacts.stream_project_contacts(project_id, args)
-      |> Stream.map(fn contact ->
-        data = if is_nil(contact.data), do: nil, else: Jason.encode!(contact.data)
-
-        [[contact.email, contact.first_name, contact.last_name, data, contact.status]]
-        |> NimbleCSV.RFC4180.dump_to_iodata()
-        |> IO.iodata_to_binary()
-      end)
-      |> Stream.chunk_every(@csv_export_chunk_size)
-      |> Enum.reduce_while(conn, fn chunk, conn ->
-        case Plug.Conn.chunk(conn, chunk) do
-          {:ok, conn} -> {:cont, conn}
-          {:error, :closed} -> {:halt, conn}
-        end
-      end)
-    end)
-    |> then(fn {:ok, conn} -> conn end)
+    filter = conn.assigns.segment.filter || %{}
+    KeilaWeb.ContactsCsvExport.stream_csv_response(conn, filename, project_id, filter: filter)
   end
 
   defp current_project(conn), do: conn.assigns.current_project

--- a/lib/keila_web/helpers/contacts_csv_export.ex
+++ b/lib/keila_web/helpers/contacts_csv_export.ex
@@ -1,0 +1,45 @@
+defmodule KeilaWeb.ContactsCsvExport do
+  @moduledoc """
+  Shared logic of exporting list of contacts to CSV file with support of streaming.
+  """
+  alias Keila.Contacts
+  import Plug.Conn
+
+  @chunk_size Application.compile_env!(:keila, KeilaWeb.ContactsCsvExport)[:chunk_size]
+
+  def stream_csv_response(conn, filename, project_id, stream_opts \\ []) do
+    stream_opts = Keyword.merge(stream_opts, max_rown: @chunk_size)
+
+    conn =
+      conn
+      |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
+      |> put_resp_header("content-type", "text/csv")
+      |> send_chunked(200)
+
+    header =
+      [["Email", "First name", "Last name", "Data", "Status"]]
+      |> NimbleCSV.RFC4180.dump_to_iodata()
+      |> IO.iodata_to_binary()
+
+    {:ok, conn} = chunk(conn, header)
+
+    Keila.Repo.transaction(fn ->
+      Contacts.stream_project_contacts(project_id, stream_opts)
+      |> Stream.map(fn contact ->
+        data = if is_nil(contact.data), do: nil, else: Jason.encode!(contact.data)
+
+        [[contact.email, contact.first_name, contact.last_name, data, contact.status]]
+        |> NimbleCSV.RFC4180.dump_to_iodata()
+        |> IO.iodata_to_binary()
+      end)
+      |> Stream.chunk_every(@chunk_size)
+      |> Enum.reduce_while(conn, fn chunk, conn ->
+        case Plug.Conn.chunk(conn, chunk) do
+          {:ok, conn} -> {:cont, conn}
+          {:error, :closed} -> {:halt, conn}
+        end
+      end)
+    end)
+    |> then(fn {:ok, conn} -> conn end)
+  end
+end

--- a/lib/keila_web/router.ex
+++ b/lib/keila_web/router.ex
@@ -97,6 +97,7 @@ defmodule KeilaWeb.Router do
     get "/projects/:project_id/contacts/new", ContactController, :new
     post "/projects/:project_id/contacts/new", ContactController, :post_new
     get "/projects/:project_id/contacts/import", ContactController, :import
+    get "/projects/:project_id/contacts/export", ContactController, :export
     get "/projects/:project_id/contacts/:id", ContactController, :edit
     put "/projects/:project_id/contacts/:id", ContactController, :post_edit
     delete "/projects/:project_id/contacts", ContactController, :delete

--- a/lib/keila_web/router.ex
+++ b/lib/keila_web/router.ex
@@ -121,6 +121,7 @@ defmodule KeilaWeb.Router do
     get "/projects/:project_id/segments/new", SegmentController, :new
     post "/projects/:project_id/segments", SegmentController, :create
     get "/projects/:project_id/segments/:id", SegmentController, :edit
+    get "/projects/:project_id/segments/:id/contacts_export", SegmentController, :contacts_export
     delete "/projects/:project_id/segments", SegmentController, :delete
 
     get "/projects/:project_id/campaigns", CampaignController, :index

--- a/lib/keila_web/templates/contact/index.html.heex
+++ b/lib/keila_web/templates/contact/index.html.heex
@@ -20,7 +20,7 @@
   <div class="flex-grow gap-4 flex flex-col sm:flex-row sm:items-center">
     <div class="flex-grow flex flex-row-reverse justify-end gap-4 sm:flex-row">
       <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
-        <%= render_icon(:document_add) %>
+        <%= render_icon(:download) %>
         <%= gettext("Export to CSV") %>
       </a>
     </div>

--- a/lib/keila_web/templates/contact/index.html.heex
+++ b/lib/keila_web/templates/contact/index.html.heex
@@ -1,4 +1,4 @@
-<div class="container flex py-8 sm:py-11 mb-4">
+<div class="container flex pt-8 sm:pt-11 mb-4">
   <div class="flex-grow gap-4 flex flex-col sm:flex-row sm:items-center">
     <h1 class="text-2xl sm:text-3xl text-gray-100">
       <%= gettext("Contacts") %>
@@ -11,6 +11,17 @@
       <a href={Routes.contact_path(@conn, :import, @current_project.id)} class="button">
         <%= render_icon(:user_add) %>
         <%= gettext("Import") %>
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="container flex pb-8 sm:pb-11 mb-4">
+  <div class="flex-grow gap-4 flex flex-col sm:flex-row sm:items-center">
+    <div class="flex-grow flex flex-row-reverse justify-end gap-4 sm:flex-row">
+      <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
+        <%= render_icon(:document_add) %>
+        <%= gettext("Export to CSV") %>
       </a>
     </div>
   </div>

--- a/lib/keila_web/templates/contact/index.html.heex
+++ b/lib/keila_web/templates/contact/index.html.heex
@@ -4,6 +4,10 @@
       <%= gettext("Contacts") %>
     </h1>
     <div class="flex-grow flex flex-row-reverse justify-end gap-4 sm:flex-row">
+      <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
+        <%= render_icon(:download) %>
+        <%= gettext("Export to CSV") %>
+      </a>
       <a href={Routes.contact_path(@conn, :new, @current_project.id)} class="button">
         <%= render_icon(:document_add) %>
         <%= gettext("Create") %>
@@ -11,17 +15,6 @@
       <a href={Routes.contact_path(@conn, :import, @current_project.id)} class="button">
         <%= render_icon(:user_add) %>
         <%= gettext("Import") %>
-      </a>
-    </div>
-  </div>
-</div>
-
-<div class="container flex pb-8 sm:pb-11 mb-4">
-  <div class="flex-grow gap-4 flex flex-col sm:flex-row sm:items-center">
-    <div class="flex-grow flex flex-row-reverse justify-end gap-4 sm:flex-row">
-      <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
-        <%= render_icon(:download) %>
-        <%= gettext("Export to CSV") %>
       </a>
     </div>
   </div>

--- a/lib/keila_web/templates/contact/index.html.heex
+++ b/lib/keila_web/templates/contact/index.html.heex
@@ -4,17 +4,19 @@
       <%= gettext("Contacts") %>
     </h1>
     <div class="flex-grow flex flex-row-reverse justify-end gap-4 sm:flex-row">
-      <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
-        <%= render_icon(:download) %>
-        <%= gettext("Export to CSV") %>
+      <%= if @contacts.count > 0 do %>
+        <a href={Routes.contact_path(@conn, :export, @current_project.id)} class="button">
+          <%= render_icon(:download) %>
+          <%= gettext("Download") %>
+        </a>
+      <% end %>
+      <a href={Routes.contact_path(@conn, :import, @current_project.id)} class="button">
+        <%= render_icon(:user_add) %>
+        <%= gettext("Import") %>
       </a>
       <a href={Routes.contact_path(@conn, :new, @current_project.id)} class="button">
         <%= render_icon(:document_add) %>
         <%= gettext("Create") %>
-      </a>
-      <a href={Routes.contact_path(@conn, :import, @current_project.id)} class="button">
-        <%= render_icon(:user_add) %>
-        <%= gettext("Import") %>
       </a>
     </div>
   </div>

--- a/lib/keila_web/templates/segment/edit_live.html.heex
+++ b/lib/keila_web/templates/segment/edit_live.html.heex
@@ -7,6 +7,13 @@
     </h1>
     <div class="flex-grow flex flex-row justify-end gap-4 sm:flex-row" x-data>
       <a
+        href={Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)}
+        class="button button--text button--large"
+      >
+        <%= render_icon(:download) %>
+        <%= gettext("Export contacts to CSV") %>
+      </a>
+      <a
         class="button button--text button--large"
         href={Routes.segment_path(@socket, :index, @current_project.id)}
         @click="setUnsavedReminder(false)"
@@ -194,17 +201,7 @@
             <%= pagination_nav(@contacts, phx_click: "change-page") %>
           </div>
         </div>
-        <div>
-          <a
-            href={
-              Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)
-            }
-            class="button"
-          >
-            <%= render_icon(:download) %>
-            <%= gettext("Export contacts to CSV") %>
-          </a>
-        </div>
+        <div></div>
       <% end %>
     </div>
   </.form>

--- a/lib/keila_web/templates/segment/edit_live.html.heex
+++ b/lib/keila_web/templates/segment/edit_live.html.heex
@@ -194,6 +194,12 @@
             <%= pagination_nav(@contacts, phx_click: "change-page") %>
           </div>
         </div>
+        <div>
+          <a href={Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)} class="button">
+            <%= render_icon(:document_add) %>
+            <%= gettext("Export contacts to CSV") %>
+          </a>
+        </div>
       <% end %>
     </div>
   </.form>

--- a/lib/keila_web/templates/segment/edit_live.html.heex
+++ b/lib/keila_web/templates/segment/edit_live.html.heex
@@ -196,7 +196,7 @@
         </div>
         <div>
           <a href={Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)} class="button">
-            <%= render_icon(:document_add) %>
+            <%= render_icon(:download) %>
             <%= gettext("Export contacts to CSV") %>
           </a>
         </div>

--- a/lib/keila_web/templates/segment/edit_live.html.heex
+++ b/lib/keila_web/templates/segment/edit_live.html.heex
@@ -195,7 +195,12 @@
           </div>
         </div>
         <div>
-          <a href={Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)} class="button">
+          <a
+            href={
+              Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)
+            }
+            class="button"
+          >
             <%= render_icon(:download) %>
             <%= gettext("Export contacts to CSV") %>
           </a>

--- a/lib/keila_web/templates/segment/edit_live.html.heex
+++ b/lib/keila_web/templates/segment/edit_live.html.heex
@@ -7,13 +7,6 @@
     </h1>
     <div class="flex-grow flex flex-row justify-end gap-4 sm:flex-row" x-data>
       <a
-        href={Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)}
-        class="button button--text button--large"
-      >
-        <%= render_icon(:download) %>
-        <%= gettext("Export contacts to CSV") %>
-      </a>
-      <a
         class="button button--text button--large"
         href={Routes.segment_path(@socket, :index, @current_project.id)}
         @click="setUnsavedReminder(false)"
@@ -165,19 +158,32 @@
     <div class="form-row">
       <%= if @valid_filter do %>
         <div>
-          <h2 class="">
-            <%= gettext("Contacts in this segment (%{count})", count: @contacts.count) %>
-          </h2>
+          <div class="sm:flex gap-4 items-center mb-4 mt-4">
+            <h2 class="font-light text-2xl">
+              <%= gettext("Contacts in this segment (%{count})", count: @contacts.count) %>
+            </h2>
+
+            <a
+              href={
+                Routes.segment_path(@socket, :contacts_export, @current_project.id, @segment.id)
+              }
+              class="button button--small"
+              target="_blank"
+            >
+              <%= render_icon(:download) %>
+              <%= gettext("Download") %>
+            </a>
+          </div>
           <table class="w-full text-sm">
             <tr class="text-left">
-              <th class="p-2">Email</th>
+              <th class="p-2 pl-0">Email</th>
               <th class="p-2 hidden lg:table-cell">First name</th>
               <th class="p-2 hidden lg:table-cell">Last name</th>
               <th class="p-2 hidden lg:table-cell">Added</th>
             </tr>
             <%= for contact <- @contacts.data do %>
               <tr>
-                <td class="p-2">
+                <td class="p-2 pl-0">
                   <a
                     class="button button--text overflow-x-hidden"
                     href={Routes.contact_path(@socket, :edit, @current_project.id, contact.id)}

--- a/test/keila_web/controllers/contact_controller_test.exs
+++ b/test/keila_web/controllers/contact_controller_test.exs
@@ -173,8 +173,8 @@ defmodule KeilaWeb.ContactControllerTest do
     assert disposition == "attachment; filename=\"contacts_#{project.id}.csv\""
 
     assert rows == [
-             "Email,First name,Last name,Data",
-             "#{contact.email},#{contact.first_name},#{contact.last_name},\"{\"\"age\"\":42}\"",
+             "Email,First name,Last name,Data,Status",
+             "#{contact.email},#{contact.first_name},#{contact.last_name},\"{\"\"age\"\":42}\",active",
              ""
            ]
   end
@@ -183,7 +183,7 @@ defmodule KeilaWeb.ContactControllerTest do
   test "GET /projects/:p_id/export CSV export contacts in multiple chunks", %{conn: conn} do
     {conn, project} = with_login_and_project(conn)
     insert!(:contact, project_id: project.id)
-    insert!(:contact, project_id: project.id)
+    insert!(:contact, project_id: project.id, status: :unreachable)
     insert!(:contact, project_id: project.id)
     insert!(:contact, project_id: project.id)
     conn = get(conn, Routes.contact_path(conn, :export, project.id))
@@ -191,5 +191,6 @@ defmodule KeilaWeb.ContactControllerTest do
     assert conn.state == :chunked
     rows = String.split(response(conn, 200), "\r\n")
     assert length(rows) == 6
+    assert Enum.at(rows, 2) =~ ~r/,unreachable/
   end
 end


### PR DESCRIPTION
This adds possibility to export contacts from a project or a segment to CSV, compatible with CSV import. It addresses #110.

I wasn't really sure where to put the buttons, so please advise for a better place.

## Screenshots

![screenshot-localhost_4000-2023 09 22-00_30_27](https://github.com/pentacent/keila/assets/119904/d24368d1-3946-4045-a8f8-8ef217f1cfc6)

![screenshot-localhost_4000-2023 09 22-01_15_06](https://github.com/pentacent/keila/assets/119904/83e5b015-28cc-414b-9f67-b6ec72c266a8)

![Screenshot_20230922_011119](https://github.com/pentacent/keila/assets/119904/d438b098-e6c4-4771-a659-bc6b0aad1acf)

## Notes

The code in these two controllers look very similar. I wasn't sure if it makes sense to abstract it out and especially - where. This feels like highly controller-level code, so pushing it to a context does not feel right. There could be a shared codebase space for just controllers, but I didn't want to just create it without consultation.