### PR TITLE
add build support for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
             pentacent/keila:${{ steps.meta.outputs.major_version }}
             pentacent/keila:${{ steps.meta.outputs.minor_version }}
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
       - uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
-      - uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -91,8 +85,6 @@ jobs:
             moritztopp/keila:${{ steps.meta.outputs.minor_version }}
           push: true
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,10 @@ jobs:
           context: .
           file: ./ops/Dockerfile
           tags: |
-            pentacent/keila:latest
-            pentacent/keila:${{ steps.meta.outputs.version }}
-            pentacent/keila:${{ steps.meta.outputs.major_version }}
-            pentacent/keila:${{ steps.meta.outputs.minor_version }}
+            moritztopp/keila:latest
+            moritztopp/keila:${{ steps.meta.outputs.version }}
+            moritztopp/keila:${{ steps.meta.outputs.major_version }}
+            moritztopp/keila:${{ steps.meta.outputs.minor_version }}
           push: true
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
-### Fixed
-- API DELETE endpoints for campaigns, contacts, segments now return the
-  correct 204 response
-
 
 ## Version 0.12.8
 
 ### Added
 - Added `MAILER_ENABLE_STARTTLS` option to configure a system mailer with STARTTLS (#247)
+
+### Fixed
+- API DELETE endpoints for campaigns, contacts, segments now return the
+  correct 204 response
 
 
 ## Version 0.12.7


### PR DESCRIPTION
Hey,
I would like to use Keila on my ARM64 Server, to do that we need to change the build config, to also publish linux/arm64 images on the Docker Hub.
Would be nice if you add it.

I just added one GitHub Action Config line, taken from:
[https://github.com/docker/setup-buildx-action?tab=readme-ov-file#inputs](url)
It just tells the docker/build-push-action to push for both platforms (amd6 and arm64).