### PR TITLE
Remove token's data inspection when creating API token without a name

### DIFF
--- a/lib/keila_web/templates/api_key/index.html.heex
+++ b/lib/keila_web/templates/api_key/index.html.heex
@@ -30,7 +30,6 @@
           <span class="text-sm"><%= @token.id %></span>
         <% else %>
           <%= @token.id %>
-          <%= inspect(@token.data) %>
         <% end %>
       </h2>
       <p>


### PR DESCRIPTION
Inspection is definitely great for debugging, but, I guess, there is no need to show the whole structure for users this way.

Closes: https://github.com/pentacent/keila/issues/368