### PR TITLE
ci(release): update github action ci build for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
     environment: build
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: actions/cache@v4
         with:
@@ -84,16 +85,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_PAT }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           file: ./ops/Dockerfile
           tags: |
             ghcr.io/pentacent/keila:latest
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           file: ./ops/Dockerfile
@@ -103,5 +105,6 @@ jobs:
           labels: |
             service=keila
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: build
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -80,7 +81,7 @@ jobs:
           echo "::set-output name=major_version::${MAJOR_VERSION}"
           awk -v version="${VERSION}" '/## Version\s/ {printit = $3 == version}; printit;' "$2" CHANGELOG.md > __CHANGELOG__.md
           cat __CHANGELOG__.md
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         with:
           context: .
           file: ./ops/Dockerfile
@@ -92,6 +93,7 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey I updated the Github Actions Release Workflow for multi-architecture support. 

- Added `setup-qemu-action` for ARM emulation.
- Replaced the Docker build with `docker/build-push-action@v5` for multi-architecture support.
