### PR TITLE
Include ISO 8601 timestamp

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -75,7 +75,7 @@ config :keila, KeilaWeb.Captcha,
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
+  format: "$dateT$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
 # Use Jason for JSON parsing in Phoenix


### PR DESCRIPTION
Example:
`2025-06-14T21:35:28.126`

I think that Logger format doesn't provide support for full ISO 8601 out of the box. Therefore, they way I implemented doesn't contain the timezone indicator in the end of the timestamp