### PR TITLE
update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,65 +1,27 @@
-# Update the VARIANT arg in docker-compose.yml to pick an Elixir version: 1.9, 1.10, 1.10.4
-ARG VARIANT="1.15.1"
-FROM elixir:${VARIANT}
+ARG ELIXIR_VERSION="1.15.8"
+FROM elixir:${ELIXIR_VERSION}
 
-# This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
-# devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Install system dependencies including liblttng-ust1 for Erlang tracing
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        curl \
+        ca-certificates \
+        liblttng-ust1 \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
-# Options for common package install script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="true"
-ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.209.6/script-library/common-debian.sh"
-ARG COMMON_SCRIPT_SHA="d35dd1711454156c9a59cc41ebe04fbff681ca0bd304f10fd5b13285d0de13b2"
-
-# Settings for Phoenix
-ARG PHOENIX_VERSION="1.6.2"
-
-# Setup nodejs
-ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/node-debian.sh"
-ARG NODE_SCRIPT_SHA="dev-mode"
-ARG NODE_VERSION="lts/*"
-ENV NVM_DIR=/usr/local/share/nvm
-ENV NVM_SYMLINK_CURRENT=true
-ENV PATH=${NVM_DIR}/current/bin:${PATH}
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-RUN apt-get update \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
-  && curl -sSL ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
-  && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
-  && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-  #
-  # [Optional] Install Node.js for use with web applications
-  && if [ "$NODE_VERSION" != "none" ]; then \
-  curl -sSL ${NODE_SCRIPT_SOURCE} -o /tmp/node-setup.sh \
-  && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${NODE_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
-  && /bin/bash /tmp/node-setup.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; \
-  fi \
-  #
-  # Install dependencies
-  && apt-get install -y build-essential cmake \
-  #
-  # Clean up
-  && apt-get autoremove -y \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* /tmp/common-setup.sh /tmp/node-setup.sh
-
-RUN su ${USERNAME} -c "mix local.hex --force \
-  && mix local.rebar --force \
-  && mix archive.install --force hex phx_new ${PHOENIX_VERSION}"
+# Install Elixir and Phoenix
+ARG PHOENIX_VERSION="1.7.10"
+RUN mix local.hex --force \
+    && mix local.rebar --force \
+    && mix archive.install --force hex phx_new ${PHOENIX_VERSION}
 
 # Install dprint
 RUN curl -fsSL https://dprint.dev/install.sh | sh \
-  && mv ~/.dprint/bin/dprint /usr/local/bin
+    && mv ~/.dprint/bin/dprint /usr/local/bin
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install additional package.
-# RUN  mix ...
+# The user setup will be handled by the common-utils feature

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,23 @@
   "service": "elixir",
   "workspaceFolder": "/workspace",
 
+  // Use 'features' to install common utilities and programming languages
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "installOhMyZsh": true,
+      "username": "vscode",
+      "userUid": 1000,
+      "userGid": 1000,
+      "upgradePackages": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "nodeGypDependencies": true,
+      "version": "lts",
+      "nvmVersion": "latest"
+    }
+  },
+
   "customizations": {
     "vscode": {
       "settings": {
@@ -38,6 +55,6 @@
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "mix deps.get && cd assets && npm install",
 
-  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // Connect as a non-root user
   "remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,12 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Elixir Version: 1.9, 1.10, 1.10.4, ...
-        VARIANT: "1.15.1"
-        # Phoenix Version: 1.4.17, 1.5.4, ...
-        PHOENIX_VERSION: "1.6.2"
-        # Node Version: 10, 11, ...
-        NODE_VERSION: "lts/*"
+        ELIXIR_VERSION: "1.15.8"
+        PHOENIX_VERSION: "1.7.10"
 
     volumes:
       - ..:/workspace:cached
@@ -20,7 +16,6 @@ services:
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-
   db:
     image: postgres:latest
     restart: unless-stopped


### PR DESCRIPTION
This was required to fix the following error:

```
== Compilation error in file extra/keila/license/license.ex ==
** (FunctionClauseError) no function clause matching in :public_key.der_decode/2    
    
    The following arguments were given to :public_key.der_decode/2:
    
        # 1
        :EcpkParameters
    
        # 2
        :asn1_NOVALUE
    
    (public_key 1.14) public_key.erl:332: :public_key.der_decode/2
    (public_key 1.14) public_key.erl:225: :public_key.pem_entry_decode/1
    extra/keila/license/license.ex:18: (module)
    (elixir 1.15.1) lib/kernel/parallel_compiler.ex:377: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```

It appears it requires an updated Elixir versus what was pinned to the devcontainer.