### PR TITLE
feat: add TZDATA_AUTOUPDATE env var to disable tzdata autocheck

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -340,6 +340,10 @@ if config_env() == :prod do
   end
 end
 
+if System.get_env("TZDATA_AUTOUPDATE") in ["disabled", "false", "0"] do
+  config :tzdata, :autoupdate, :disabled
+end
+
 if config_env() == :test do
   db_url = System.get_env("DB_URL")
 


### PR DESCRIPTION
## Summary

Adds support for the `TZDATA_AUTOUPDATE` environment variable to disable tzdata's automatic update checks. Set `TZDATA_AUTOUPDATE=disabled` (or `false` or `0`) to prevent the autoupdate.

## Why

In read-only container environments like RedHat OpenShift, tzdata's autoupdate attempts to write to an internal file and fails repeatedly, flooding pod logs with errors every few seconds.

## Changes

`config/runtime.exs`: Added a check before the test config block that reads `TZDATA_AUTOUPDATE` and configures `:tzdata, :autoupdate, :disabled` when set. Runs in all environments (not just prod) since containers can run in any Mix env.

## Usage

```bash
TZDATA_AUTOUPDATE=disabled mix phx.server
```

Fixes #519

This contribution was developed with AI assistance (Claude Code).