### PR TITLE
Fix: Unable to create sender using shared config

### DIFF
--- a/lib/keila_web/templates/sender/_config_new.html.heex
+++ b/lib/keila_web/templates/sender/_config_new.html.heex
@@ -10,14 +10,22 @@
     end
 
   tab_data =
-    "{ tab: '#{tab}', senderType: $el.querySelector('#form_config_type,#shared_sender_config_type').value }" %>
+    "{ tab: '#{tab}', senderType: $el.querySelector('#form_config_type,#shared_sender_config_type').value }"
+
+  sender_types =
+    if assigns[:shared_senders] do
+      shared_sender_types = Enum.map(@shared_senders, &"shared_#{&1.config.type}") |> Enum.uniq()
+      @sender_adapters ++ shared_sender_types
+    else
+      @sender_adapters
+    end %>
 
   <div
     class="tabs"
     x-data={tab_data}
     x-init="$nextTick(() => { if (! $el.querySelector('button.tab-label.active')) {$el.querySelector('button.tab-label').click()} })"
   >
-    {select(fc, :type, @sender_adapters, x_model: "senderType", class: "hidden")}
+    {select(fc, :type, sender_types, x_model: "senderType", class: "hidden")}
 
     <%= for adapter <- @sender_adapters do %>
       <% class = "{ 'active': tab === '#{adapter}' }"


### PR DESCRIPTION
Hello 👋🏼 

This PR is mostly a demonstration of an issue I encountered while trying to create a new project-level sender using configuration from a shared sender. In this situation, "Save" actions quietly failed validation because the `config => type` param was the default/first value of `smtp` instead of the correct value `shared_*` (for example, `shared_local`). Parameter validation errors were displayed under the SMTP tab, which was not active.

When shared senders are available, we also need to include their `config.type` in the `select` that gets controlled by `senderType`. This PR is one way to accomplish this, but there may be better ways.

❤️  Love this project. Thank you for your work!