### PR TITLE
Add GET /api/v1/campaigns/:id/stats endpoint

### DIFF
--- a/lib/keila_web/api/controllers/api_campaign_controller.ex
+++ b/lib/keila_web/api/controllers/api_campaign_controller.ex
@@ -164,5 +164,26 @@ defmodule KeilaWeb.ApiCampaignController do
     end
   end
 
+  operation(:stats,
+    summary: "Campaign Stats",
+    description: "Retrieve delivery and engagement statistics for a campaign.",
+    parameters: [id: [in: :path, type: :string, description: "Campaign ID"]],
+    responses: [
+      ok: {"Campaign stats response", "application/json", Schemas.MailingsCampaign.StatsResponse}
+    ]
+  )
+
+  @spec stats(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def stats(conn, %{id: id}) do
+    campaign = Mailings.get_project_campaign(project_id(conn), id)
+
+    if campaign do
+      stats = Mailings.get_campaign_stats(campaign.id)
+      render(conn, "stats.json", %{campaign_id: campaign.id, stats: stats})
+    else
+      Errors.send_404(conn)
+    end
+  end
+
   defp project_id(conn), do: conn.assigns.current_project.id
 end

--- a/lib/keila_web/api/schemas/mailings_campaign.ex
+++ b/lib/keila_web/api/schemas/mailings_campaign.ex
@@ -227,3 +227,82 @@ defmodule KeilaWeb.Api.Schemas.MailingsCampaign.DeliveryQueuedResponse do
     }
   })
 end
+
+defmodule KeilaWeb.Api.Schemas.MailingsCampaign.StatsResponse do
+  use KeilaWeb.Api.Schema
+
+  build_open_api_schema(%{
+    campaign_id: %{
+      type: :string,
+      description: "Campaign ID",
+      example: "mc_12345"
+    },
+    status: %{
+      type: :string,
+      enum: [:unsent, :preparing, :sending, :sent, :insufficient_credits, :account_not_active],
+      description: "Current status of the campaign"
+    },
+    recipients_count: %{
+      type: :integer,
+      description: "Total number of recipients",
+      example: 1000
+    },
+    sent_count: %{
+      type: :integer,
+      description: "Number of sent messages",
+      example: 950
+    },
+    open_count: %{
+      type: :integer,
+      description: "Number of unique opens",
+      example: 450
+    },
+    click_count: %{
+      type: :integer,
+      description: "Number of unique clicks",
+      example: 120
+    },
+    failed_count: %{
+      type: :integer,
+      description: "Number of failed deliveries",
+      example: 5
+    },
+    unsubscribe_count: %{
+      type: :integer,
+      description: "Number of unsubscribes",
+      example: 3
+    },
+    hard_bounce_count: %{
+      type: :integer,
+      description: "Number of hard bounces",
+      example: 2
+    },
+    complaint_count: %{
+      type: :integer,
+      description: "Number of complaints (spam reports)",
+      example: 1
+    },
+    opened_at_series: %{
+      type: :array,
+      description: "Time series of opens (hour, count) over 24 hours after sending",
+      items: %{
+        type: :map,
+        properties: %{
+          hour: %{type: :integer, description: "Hour offset from sent_at"},
+          count: %{type: :integer, description: "Number of opens in this hour"}
+        }
+      }
+    },
+    clicked_at_series: %{
+      type: :array,
+      description: "Time series of clicks (hour, count) over 24 hours after sending",
+      items: %{
+        type: :map,
+        properties: %{
+          hour: %{type: :integer, description: "Hour offset from sent_at"},
+          count: %{type: :integer, description: "Number of clicks in this hour"}
+        }
+      }
+    }
+  })
+end

--- a/lib/keila_web/api/views/api_campaign_view.ex
+++ b/lib/keila_web/api/views/api_campaign_view.ex
@@ -19,6 +19,30 @@ defmodule KeilaWeb.ApiCampaignView do
     }
   end
 
+  def render("stats.json", %{campaign_id: campaign_id, stats: stats}) do
+    stats
+    |> Map.take([
+      :status,
+      :recipients_count,
+      :sent_count,
+      :open_count,
+      :click_count,
+      :failed_count,
+      :unsubscribe_count,
+      :hard_bounce_count,
+      :complaint_count,
+      :opened_at_series,
+      :clicked_at_series
+    ])
+    |> Map.put(:campaign_id, campaign_id)
+    |> then(fn data ->
+      data
+      |> Map.update!(:opened_at_series, &Enum.map(&1, fn {hour, count} -> %{hour: hour, count: count} end))
+      |> Map.update!(:clicked_at_series, &Enum.map(&1, fn {hour, count} -> %{hour: hour, count: count} end))
+    end)
+    |> then(&%{"data" => &1})
+  end
+
   def render("delivery_queued.json", %{campaign: campaign}) do
     %{
       "data" => %{

--- a/lib/keila_web/router.ex
+++ b/lib/keila_web/router.ex
@@ -244,6 +244,7 @@ defmodule KeilaWeb.Router do
 
     post "/campaigns/:id/actions/send", ApiCampaignController, :deliver
     post "/campaigns/:id/actions/schedule", ApiCampaignController, :schedule
+    get "/campaigns/:id/stats", ApiCampaignController, :stats
 
     resources "/forms", ApiFormController, only: [:index, :show, :create, :update, :delete]
     post "/forms/:id/actions/submit", ApiFormController, :submit

--- a/test/keila_web/api/api_campaign_controller_test.exs
+++ b/test/keila_web/api/api_campaign_controller_test.exs
@@ -165,6 +165,78 @@ defmodule KeilaWeb.ApiCampaignControllerTest do
     end
   end
 
+  describe "GET /api/v1/campaigns/:id/stats" do
+    @tag :api_campaign_controller
+    test "returns stats for unsent campaign", %{authorized_conn: conn, project: project} do
+      campaign = insert!(:mailings_campaign, project_id: project.id)
+      campaign_id = campaign.id
+
+      conn = get(conn, Routes.api_campaign_path(conn, :stats, campaign_id))
+
+      assert %{
+               "data" => %{
+                 "campaign_id" => ^campaign_id,
+                 "status" => "unsent",
+                 "recipients_count" => 0,
+                 "sent_count" => 0,
+                 "open_count" => 0,
+                 "click_count" => 0,
+                 "failed_count" => 0,
+                 "unsubscribe_count" => 0,
+                 "hard_bounce_count" => 0,
+                 "complaint_count" => 0,
+                 "opened_at_series" => [],
+                 "clicked_at_series" => []
+               }
+             } = json_response(conn, 200)
+    end
+
+    @tag :api_campaign_controller
+    test "returns 404 for non-existent campaign", %{authorized_conn: conn} do
+      conn = get(conn, Routes.api_campaign_path(conn, :stats, "nonexistent"))
+
+      assert json_response(conn, 404)
+    end
+
+    @tag :api_campaign_controller
+    test "returns stats with tracking data for sent campaign",
+         %{authorized_conn: conn, project: project} do
+      sender =
+        insert!(:mailings_sender,
+          project_id: project.id,
+          config: %{type: "test"}
+        )
+
+      campaign =
+        insert!(:mailings_campaign,
+          project_id: project.id,
+          sender_id: sender.id,
+          settings: %{type: :text}
+        )
+
+      campaign_id = campaign.id
+      _contacts = insert_n!(:contact, 3, fn _ -> %{project_id: project.id} end)
+
+      :ok = Keila.Mailings.deliver_campaign(campaign_id)
+      assert %{success: 1} = Oban.drain_queue(queue: :campaign_renderer)
+      :ok = Keila.MailingsSchedulerTestHelper.schedule_messages()
+      assert %{success: 3} = Oban.drain_queue(queue: :mailer)
+
+      conn = get(conn, Routes.api_campaign_path(conn, :stats, campaign_id))
+
+      assert %{
+               "data" => %{
+                 "campaign_id" => ^campaign_id,
+                 "status" => "sent",
+                 "recipients_count" => 3,
+                 "sent_count" => 3,
+                 "opened_at_series" => [],
+                 "clicked_at_series" => []
+               }
+             } = json_response(conn, 200)
+    end
+  end
+
   describe "POST /api/v1/campaigns/:id/actions/schedule" do
     @tag :api_campaign_controller
     test "returns updated campaign", %{authorized_conn: conn, project: project} do


### PR DESCRIPTION
Adds a new API endpoint at GET /api/v1/campaigns/:id/stats that returns campaign delivery and engagement statistics (sent count, open/click counts, time series, etc.) plus the campaign_id.

New controller action with OpenApiSpex spec, StatsResponse schema, stats.json view render, route, and tests for unsent/sent/non-existent campaigns.