### PR TITLE
Fix contact status when downgrading to unsubscribed

### DIFF
--- a/lib/keila/contacts/contacts.ex
+++ b/lib/keila/contacts/contacts.ex
@@ -472,7 +472,7 @@ defmodule Keila.Contacts do
   def downgrade_contact_status(contact_id, :unsubscribed) do
     with %Contact{} = contact <- get_contact(contact_id) do
       if contact.status != :unsubscribed do
-        contact |> change(%{status: :unreachable}) |> Repo.update!()
+        contact |> change(%{status: :unsubscribed}) |> Repo.update!()
       else
         contact
       end


### PR DESCRIPTION
Hello 👋🏼 

I noticed that when calling `downgrade_contact_status/2` with a status of `:unsubscribed`, it results in the contact having the status `:unreachable` instead.

Cheers!