### PR TITLE
Improve segment filters for custom data fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Added
+- Segment filter editor now supports more operators for custom data: *starts with*, *ends with*, *includes*, *is greater than*, *is smaller than*, *is after date*, and *is before date*
 
 ## Version 0.30.2
 

--- a/lib/keila/contacts/query.ex
+++ b/lib/keila/contacts/query.ex
@@ -27,6 +27,25 @@ defmodule Keila.Contacts.Query do
   - `"$like"` - queries if the field matches using the SQL `ILIKE` statement.
      `%{"email" => %{"$like" => "%keila.io"}}`
 
+  ## Filtering on custom data (`data.*`)
+  Any `data.`-prefixed path filters on the contact's JSONB `data` field, e.g.
+  `%{"data.age" => %{"$gt" => 40}}`. All operators above are supported. Because
+  custom data is untyped JSONB, comparison operators (`$gt`, `$gte`, `$lt`,
+  `$lte`) require the stored value and the filter value to be the same JSON
+  type, and only support numbers and strings:
+  - If the field is missing, or its stored value is a different JSON type than
+    the filter value (e.g. filtering `$gt: 40` against a stored string, or
+    `$gt: "40"` against a stored number), the contact is filtered out rather
+    than compared. This avoids JSONB's type-rank ordering (`Object > Array >
+    Boolean > Number > String > Null`), which would otherwise silently produce
+    a match/non-match based on type rather than value.
+  - Numbers compare numerically when both sides are JSON numbers.
+  - Strings (e.g. dates) compare lexicographically when both sides are JSON
+    strings, which is only correct for zero-padded ISO 8601 date values.
+  - Booleans, arrays, and objects never match `$gt`/`$gte`/`$lt`/`$lte`, since
+    there's no sensible ordering to apply.
+  `$like` operates on the text projection of the value and works for any scalar.
+
   # Filtering on received messages (messages)
   A `messages` map can be defined to filter contacts based on their received messages.
   All status fields (like `"opened_at"`) can be defined, as well as `"campaign_id"`.
@@ -225,17 +244,15 @@ defmodule Keila.Contacts.Query do
 
   defp build_data_condition(path, input)
 
-  defp build_data_condition(path, %{"$gt" => value}),
-    do: dynamic([c], fragment("?#>?", c.data, ^path) > ^value)
+  defp build_data_condition(path, %{"$gt" => value}), do: build_data_comparison(path, value, :gt)
 
   defp build_data_condition(path, %{"$gte" => value}),
-    do: dynamic([c], fragment("?#>?", c.data, ^path) >= ^value)
+    do: build_data_comparison(path, value, :gte)
 
-  defp build_data_condition(path, %{"$lt" => value}),
-    do: dynamic([c], fragment("?#>?", c.data, ^path) < ^value)
+  defp build_data_condition(path, %{"$lt" => value}), do: build_data_comparison(path, value, :lt)
 
   defp build_data_condition(path, %{"$lte" => value}),
-    do: dynamic([c], fragment("?#>?", c.data, ^path) <= ^value)
+    do: build_data_comparison(path, value, :lte)
 
   defp build_data_condition(path, %{"$empty" => empty?}) when is_boolean(empty?) do
     is_null = dynamic([c], is_nil(fragment("?#>>?", c.data, ^path)))
@@ -275,6 +292,131 @@ defmodule Keila.Contacts.Query do
     array_contains = dynamic([c], fragment("?#>? @> ?", c.data, ^path, ^value_in_array))
     dynamic([c], ^contains or ^array_contains)
   end
+
+  # Custom data is untyped JSONB, so `$gt`/`$gte`/`$lt`/`$lte` only make sense
+  # between two values of the same JSON type. Comparing across types (e.g. a
+  # number stored where a string is filtered for) would otherwise fall back to
+  # JSONB's type-rank ordering (Object > Array > Boolean > Number > String >
+  # Null), silently matching/excluding rows based on type rather than value.
+  # The CASE guard (rather than a plain `and`) is required: Postgres does not
+  # guarantee left-to-right/short-circuit evaluation of ANDed WHERE clauses, so
+  # a bare type-check-and-cast could still attempt (and fail on) the numeric
+  # cast for a row whose value isn't actually numeric.
+  defp build_data_comparison(path, value, :gt) when is_number(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'number' THEN (?#>>?)::numeric > ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :gte) when is_number(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'number' THEN (?#>>?)::numeric >= ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :lt) when is_number(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'number' THEN (?#>>?)::numeric < ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :lte) when is_number(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'number' THEN (?#>>?)::numeric <= ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :gt) when is_binary(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'string' THEN (?#>>?) > ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :gte) when is_binary(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'string' THEN (?#>>?) >= ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :lt) when is_binary(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'string' THEN (?#>>?) < ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  defp build_data_comparison(path, value, :lte) when is_binary(value) do
+    dynamic(
+      [c],
+      fragment(
+        "CASE WHEN jsonb_typeof(?#>?) = 'string' THEN (?#>>?) <= ? ELSE false END",
+        c.data,
+        ^path,
+        c.data,
+        ^path,
+        ^value
+      )
+    )
+  end
+
+  # Neither a number nor a string (e.g. a boolean, list, or map) - there's no
+  # sensible ordering to apply, so the condition matches nothing.
+  defp build_data_comparison(_path, _value, _op), do: false
 
   defp maybe_sort(query, opts) do
     case Keyword.get(opts, :sort) do

--- a/lib/keila_web/live/segment_edit_live.ex
+++ b/lib/keila_web/live/segment_edit_live.ex
@@ -51,6 +51,13 @@ defmodule KeilaWeb.SegmentEditLive do
       ],
       "data" => [
         %{name: "matches", label: gettext("matches")},
+        %{name: "starts_with", label: gettext("starts with")},
+        %{name: "ends_with", label: gettext("ends with")},
+        %{name: "includes", label: gettext("includes")},
+        %{name: "gt", label: gettext("is greater than")},
+        %{name: "lt", label: gettext("is smaller than")},
+        %{name: "after", label: gettext("is after date")},
+        %{name: "before", label: gettext("is before date")},
         %{name: "empty", label: gettext("is empty")},
         %{name: "not_empty", label: gettext("is not empty")}
       ],
@@ -401,6 +408,17 @@ defmodule KeilaWeb.SegmentEditLive do
     %{"value" => %{"key" => field, "match" => condition}}
   end
 
+  defp filter_condition_to_form_data("custom", "data." <> field, %{"$like" => value}) do
+    {widget, match} = classify_like(value)
+    %{"value" => %{"key" => field, "match" => match}, "widget" => widget}
+  end
+
+  defp filter_condition_to_form_data("custom", "data." <> field, %{"$gt" => value}),
+    do: custom_comparison_to_form_data(field, value, "gt", "after")
+
+  defp filter_condition_to_form_data("custom", "data." <> field, %{"$lt" => value}),
+    do: custom_comparison_to_form_data(field, value, "lt", "before")
+
   defp filter_condition_to_form_data("custom", "data." <> field, %{"$empty" => true}) do
     %{"value" => %{"key" => field}, "widget" => "empty"}
   end
@@ -452,6 +470,28 @@ defmodule KeilaWeb.SegmentEditLive do
       end
 
     %{"value" => %{"campaign_id" => campaign_id}, "widget" => widget}
+  end
+
+  # A numeric value maps to the numeric widgets (gt/lt); an ISO 8601 string maps
+  # to the date widgets (after/before). Any other value raises, so the query
+  # gracefully falls back to manual-only editing (see `filter_to_form_data/1`).
+  defp custom_comparison_to_form_data(field, value, number_widget, _date_widget)
+       when is_number(value) do
+    %{"value" => %{"key" => field, "match" => to_string(value)}, "widget" => number_widget}
+  end
+
+  defp custom_comparison_to_form_data(field, value, _number_widget, date_widget)
+       when is_binary(value) do
+    {:ok, datetime, _} = DateTime.from_iso8601(value)
+
+    date_value = %{
+      "key" => field,
+      "date" => DateTime.to_iso8601(datetime),
+      "time" => DateTime.to_iso8601(datetime),
+      "timezone" => "Etc/UTC"
+    }
+
+    %{"value" => date_value, "widget" => date_widget}
   end
 
   # Transforms form_data to filter
@@ -547,6 +587,48 @@ defmodule KeilaWeb.SegmentEditLive do
     end
   end
 
+  defp form_data_condition_to_filter(_field, "custom", widget, value)
+       when widget in ["starts_with", "ends_with", "includes"] and is_map(value) do
+    key = value["key"]
+    match = value["match"]
+
+    if is_binary(key) && key != "" && is_binary(match) && match != "" do
+      pattern =
+        case widget do
+          "starts_with" -> match <> "%"
+          "ends_with" -> "%" <> match
+          "includes" -> "%" <> match <> "%"
+        end
+
+      %{("data." <> key) => %{"$like" => pattern}}
+    end
+  end
+
+  defp form_data_condition_to_filter(_field, "custom", widget, value)
+       when widget in ["gt", "lt"] and is_map(value) do
+    key = value["key"]
+
+    with true <- is_binary(key) and key != "",
+         {:ok, number} <- parse_number(value["match"]) do
+      %{("data." <> key) => %{("$" <> widget) => number}}
+    else
+      _ -> nil
+    end
+  end
+
+  defp form_data_condition_to_filter(_field, "custom", widget, value)
+       when widget in ["before", "after"] and is_map(value) do
+    key = value["key"]
+    op = if widget == "before", do: "$lt", else: "$gt"
+
+    with true <- is_binary(key) and key != "",
+         {:ok, iso8601} <- custom_date_to_iso8601(value) do
+      %{("data." <> key) => %{op => iso8601}}
+    else
+      _ -> nil
+    end
+  end
+
   defp form_data_condition_to_filter(_field, "custom", "empty", value) when is_map(value) do
     key = value["key"]
 
@@ -604,6 +686,55 @@ defmodule KeilaWeb.SegmentEditLive do
 
   defp form_data_condition_to_filter(_, _, _, _) do
     nil
+  end
+
+  # Detects the widget encoded by an ILIKE pattern's `%` placement and returns
+  # the widget name together with the unwrapped match value.
+  defp classify_like(value) do
+    cond do
+      String.starts_with?(value, "%") && String.ends_with?(value, "%") ->
+        {"includes", String.slice(value, 1..-2//1)}
+
+      String.starts_with?(value, "%") ->
+        {"ends_with", String.slice(value, 1..-1//1)}
+
+      String.ends_with?(value, "%") ->
+        {"starts_with", String.slice(value, 0..-2//1)}
+    end
+  end
+
+  # Custom data is untyped JSONB. Numeric comparisons (`$gt`/`$lt`) must send the
+  # value as a JSON number so PostgreSQL compares numerically rather than by
+  # JSONB type rank (see `Keila.Contacts.Query` moduledoc).
+  defp parse_number(value) when is_number(value), do: {:ok, value}
+
+  defp parse_number(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} ->
+        {:ok, int}
+
+      _ ->
+        case Float.parse(value) do
+          {float, ""} -> {:ok, float}
+          _ -> :error
+        end
+    end
+  end
+
+  defp parse_number(_), do: :error
+
+  # Converts the date-picker value into an ISO 8601 string. Custom-data dates are
+  # stored as strings, so they are compared lexicographically and must be ISO
+  # 8601 to compare correctly.
+  defp custom_date_to_iso8601(value) do
+    with {:ok, date} <- Date.from_iso8601(to_string(value["date"])),
+         {:ok, time} <- Time.from_iso8601(to_string(value["time"]) <> ":00"),
+         {:ok, datetime} <- DateTime.new(date, time, value["timezone"] || "Etc/UTC"),
+         {:ok, utc_datetime} <- DateTime.shift_zone(datetime, "Etc/UTC") do
+      {:ok, DateTime.to_iso8601(utc_datetime)}
+    else
+      _ -> :error
+    end
   end
 
   # Ensures correct types and widgets for all conditions

--- a/lib/keila_web/views/segment_view.ex
+++ b/lib/keila_web/views/segment_view.ex
@@ -93,9 +93,8 @@ defmodule KeilaWeb.SegmentView do
   defp render_widget(index, condition = %{"type" => "custom"}) do
     value = condition["value"] || %{}
     key = value["key"]
-    match = value["match"]
     widget = condition["widget"] || "matches"
-    assigns = %{index: index, key: key, match: match, widget: widget}
+    assigns = %{index: index, key: key, value: value, widget: widget}
 
     ~H"""
     <label for={"#{@index}[value][key]"} class="self-center text-right">
@@ -108,18 +107,7 @@ defmodule KeilaWeb.SegmentView do
       value={@key}
       class="text-black w-28"
     />
-    <%= if @widget == "matches" do %>
-      <label for={"#{@index}[value][match]"} class="self-center text-right">
-        {gettext("Match:")}
-      </label>
-      <input
-        id={"#{@index}[value][match]"}
-        name={"#{@index}[value][match]"}
-        type="text"
-        value={@match}
-        class="text-black"
-      />
-    <% end %>
+    {render_custom_value(@index, @widget, @value)}
     """
   end
 
@@ -153,5 +141,59 @@ defmodule KeilaWeb.SegmentView do
   defp render_widget(_widget, field_form_data) do
     assigns = %{condition: field_form_data}
     ~H"<p>{inspect(@condition)}</p>"
+  end
+
+  # Renders the value input for a custom-data condition based on its operator.
+
+  # Text operators share a plain text input for the match value.
+  defp render_custom_value(index, widget, value)
+       when widget in ["matches", "starts_with", "ends_with", "includes"] do
+    assigns = %{index: index, match: value["match"]}
+
+    ~H"""
+    <label for={"#{@index}[value][match]"} class="self-center text-right">
+      {gettext("Match:")}
+    </label>
+    <input
+      id={"#{@index}[value][match]"}
+      name={"#{@index}[value][match]"}
+      type="text"
+      value={@match}
+      class="text-black"
+    />
+    """
+  end
+
+  # Numeric operators use a number input so the value is coerced to a number.
+  defp render_custom_value(index, widget, value) when widget in ["gt", "lt"] do
+    assigns = %{index: index, match: value["match"]}
+
+    ~H"""
+    <label for={"#{@index}[value][match]"} class="self-center text-right">
+      {gettext("Value:")}
+    </label>
+    <input
+      id={"#{@index}[value][match]"}
+      name={"#{@index}[value][match]"}
+      type="number"
+      step="any"
+      value={@match}
+      class="text-black"
+    />
+    """
+  end
+
+  # Date operators reuse the built-in date field's date / time / timezone inputs.
+  defp render_custom_value(index, widget, value) when widget in ["before", "after"] do
+    render_widget(index, %{"type" => "date", "widget" => "lt", "value" => value})
+  end
+
+  # empty / not_empty need no value input.
+  defp render_custom_value(index, _widget, _value) do
+    assigns = %{index: index}
+
+    ~H"""
+    <input id={"#{@index}[value][match]"} name={"#{@index}[value][match]"} type="hidden" value="" />
+    """
   end
 end

--- a/test/keila/contacts/contacts_query_test.exs
+++ b/test/keila/contacts/contacts_query_test.exs
@@ -246,6 +246,95 @@ defmodule Keila.ContactsQueryTest do
   end
 
   @tag :contacts_query
+  test "filter custom data with text operators ($like)" do
+    c1 = insert!(:contact, %{data: %{"name" => "Alice"}})
+    c2 = insert!(:contact, %{data: %{"name" => "Bob"}})
+
+    # starts_with
+    assert [c1] == filter_contacts(%{"data.name" => %{"$like" => "Al%"}})
+    # ends_with
+    assert [c2] == filter_contacts(%{"data.name" => %{"$like" => "%ob"}})
+    # includes
+    assert [c1] == filter_contacts(%{"data.name" => %{"$like" => "%lic%"}})
+    # ILIKE is case-insensitive
+    assert [c1] == filter_contacts(%{"data.name" => %{"$like" => "alice"}})
+  end
+
+  @tag :contacts_query
+  test "filter custom data numeric comparison compares numerically, not lexically" do
+    # Values chosen so numeric and string comparison disagree:
+    # numeric 100 > 9, but lexically "100" < "9".
+    c_small = insert!(:contact, %{data: %{"age" => 9}})
+    c_large = insert!(:contact, %{data: %{"age" => 100}})
+
+    assert [c_large] == filter_contacts(%{"data.age" => %{"$gt" => 50}})
+    assert [c_small] == filter_contacts(%{"data.age" => %{"$lt" => 50}})
+    assert [c_large] == filter_contacts(%{"data.age" => %{"$gte" => 100}})
+    assert [c_small] == filter_contacts(%{"data.age" => %{"$lte" => 9}})
+  end
+
+  @tag :contacts_query
+  test "filter custom data date comparison on ISO 8601 strings" do
+    c_early = insert!(:contact, %{data: %{"signup" => "2024-01-15"}})
+    c_late = insert!(:contact, %{data: %{"signup" => "2024-06-20"}})
+
+    # Date-only stored value compared against a date literal
+    assert [c_late] == filter_contacts(%{"data.signup" => %{"$gt" => "2024-03-01"}})
+    assert [c_early] == filter_contacts(%{"data.signup" => %{"$lt" => "2024-03-01"}})
+
+    # ...and against a full ISO 8601 datetime literal (as emitted by the editor)
+    assert [c_late] == filter_contacts(%{"data.signup" => %{"$gt" => "2024-03-01T00:00:00Z"}})
+    assert [c_early] == filter_contacts(%{"data.signup" => %{"$lt" => "2024-03-01T00:00:00Z"}})
+  end
+
+  @tag :contacts_query
+  test "filter custom data comparison operators exclude contacts missing the field" do
+    c_present = insert!(:contact, %{data: %{"age" => 30}})
+    _c_missing = insert!(:contact, %{data: %{"other_field" => "foo"}})
+    _c_no_data = insert!(:contact)
+
+    assert [c_present] == filter_contacts(%{"data.age" => %{"$gt" => 10}})
+    assert [c_present] == filter_contacts(%{"data.age" => %{"$gte" => 30}})
+    assert [c_present] == filter_contacts(%{"data.age" => %{"$lt" => 50}})
+    assert [c_present] == filter_contacts(%{"data.age" => %{"$lte" => 30}})
+  end
+
+  @tag :contacts_query
+  test "filter custom data comparison operators exclude type-incompatible values instead of comparing" do
+    c_number = insert!(:contact, %{data: %{"age" => 9}})
+    c_string = insert!(:contact, %{data: %{"age" => "thirty"}})
+    c_bool = insert!(:contact, %{data: %{"age" => true}})
+    c_list = insert!(:contact, %{data: %{"age" => [1, 2]}})
+    c_object = insert!(:contact, %{data: %{"age" => %{"years" => 9}}})
+    c_null = insert!(:contact, %{data: %{"age" => nil}})
+
+    # A number filter must only ever match a number field - not a boolean, which
+    # JSONB's type-rank ordering would otherwise rank above every number.
+    assert [c_number] == filter_contacts(%{"data.age" => %{"$gt" => 5}})
+    assert [] == filter_contacts(%{"data.age" => %{"$gt" => 100}})
+
+    for op <- ["$gt", "$gte", "$lt", "$lte"] do
+      string_filtered = filter_contacts(%{"data.age" => %{op => "5"}})
+      number_filtered = filter_contacts(%{"data.age" => %{op => 5}})
+
+      # Only the same-typed value may ever match; other JSON types never do,
+      # even though JSONB's type-rank ordering would otherwise rank
+      # Boolean > Number > String for some of these comparisons.
+      refute c_number in string_filtered
+      refute c_bool in string_filtered
+      refute c_list in string_filtered
+      refute c_object in string_filtered
+      refute c_null in string_filtered
+
+      refute c_string in number_filtered
+      refute c_bool in number_filtered
+      refute c_list in number_filtered
+      refute c_object in number_filtered
+      refute c_null in number_filtered
+    end
+  end
+
+  @tag :contacts_query
   test "filter for contact being included in campaign", %{project: project} do
     c = insert!(:contact, %{project_id: project.id})
     campaign1 = insert!(:mailings_campaign, %{project_id: project.id})

--- a/test/keila_web/live/segment_edit_live_test.exs
+++ b/test/keila_web/live/segment_edit_live_test.exs
@@ -1,0 +1,139 @@
+defmodule KeilaWeb.SegmentEditLiveTest do
+  use KeilaWeb.ConnCase
+  import Phoenix.LiveViewTest
+  alias Keila.Contacts
+
+  @endpoint KeilaWeb.Endpoint
+
+  setup %{conn: conn} do
+    {conn, project} = with_login_and_project(conn)
+    %{conn: conn, project: project}
+  end
+
+  defp edit_live(conn, project, filter) do
+    segment = insert!(:contacts_segment, project_id: project.id, filter: filter)
+    {:ok, view, html} = live(conn, Routes.segment_path(conn, :edit, project.id, segment.id))
+    {view, html}
+  end
+
+  # Wraps a single custom-data condition in the group/condition form structure.
+  defp custom_form_data(widget, value) do
+    %{
+      "0" => %{
+        "0" => %{
+          "field" => "data",
+          "type" => "custom",
+          "widget" => widget,
+          "value" => value
+        }
+      }
+    }
+  end
+
+  defp wrap(condition), do: %{"$or" => [%{"$and" => [condition]}]}
+
+  # Runs form data through the editor and returns the persisted filter. Saving
+  # reads the actual filter map back from the database, avoiding any HTML
+  # entity-encoding in the query textarea.
+  defp compiled_filter(conn, project, form_data) do
+    segment = insert!(:contacts_segment, project_id: project.id, filter: %{})
+
+    {:ok, view, _html} =
+      live(conn, Routes.segment_path(conn, :edit, project.id, segment.id))
+
+    render_hook(view, "save", %{"segment" => %{"name" => "Test"}, "filter" => form_data})
+    Contacts.get_segment(segment.id).filter
+  end
+
+  defp selected_widget(html) do
+    {:ok, doc} = Floki.parse_document(html)
+
+    doc
+    |> Floki.find("select[name$='[widget]'] option[selected]")
+    |> Floki.attribute("value")
+  end
+
+  defp input_value(html, suffix) do
+    {:ok, doc} = Floki.parse_document(html)
+
+    doc
+    |> Floki.find("input[name$='#{suffix}']")
+    |> Floki.attribute("value")
+  end
+
+  describe "custom data operators — form to filter" do
+    test "starts_with / ends_with / includes compile to $like patterns", %{
+      conn: conn,
+      project: project
+    } do
+      assert compiled_filter(conn, project, custom_form_data("starts_with", %{"key" => "city", "match" => "Ber"})) ==
+               wrap(%{"data.city" => %{"$like" => "Ber%"}})
+
+      assert compiled_filter(conn, project, custom_form_data("ends_with", %{"key" => "city", "match" => "lin"})) ==
+               wrap(%{"data.city" => %{"$like" => "%lin"}})
+
+      assert compiled_filter(conn, project, custom_form_data("includes", %{"key" => "city", "match" => "erl"})) ==
+               wrap(%{"data.city" => %{"$like" => "%erl%"}})
+    end
+
+    test "greater/smaller than compile to numeric $gt/$lt (not strings)", %{
+      conn: conn,
+      project: project
+    } do
+      # The value must be a JSON number, otherwise JSONB comparison is wrong.
+      assert compiled_filter(conn, project, custom_form_data("gt", %{"key" => "age", "match" => "40"})) ==
+               wrap(%{"data.age" => %{"$gt" => 40}})
+
+      assert compiled_filter(conn, project, custom_form_data("lt", %{"key" => "score", "match" => "3.5"})) ==
+               wrap(%{"data.score" => %{"$lt" => 3.5}})
+    end
+
+    test "a non-numeric value for a numeric operator is dropped", %{conn: conn, project: project} do
+      assert compiled_filter(conn, project, custom_form_data("gt", %{"key" => "age", "match" => "abc"})) ==
+               %{"$or" => []}
+    end
+
+    test "is after / is before date compile to ISO 8601 $gt/$lt", %{conn: conn, project: project} do
+      value = %{
+        "key" => "signup",
+        "date" => "2024-03-01",
+        "time" => "10:30",
+        "timezone" => "Etc/UTC"
+      }
+
+      assert compiled_filter(conn, project, custom_form_data("after", value)) ==
+               wrap(%{"data.signup" => %{"$gt" => "2024-03-01T10:30:00Z"}})
+
+      assert compiled_filter(conn, project, custom_form_data("before", value)) ==
+               wrap(%{"data.signup" => %{"$lt" => "2024-03-01T10:30:00Z"}})
+    end
+  end
+
+  describe "custom data operators — filter to form (round-trip)" do
+    test "a numeric comparison filter opens in the visual editor", %{conn: conn, project: project} do
+      {_view, html} = edit_live(conn, project, wrap(%{"data.age" => %{"$gt" => 40}}))
+
+      refute html =~ "can only be edited manually"
+      assert selected_widget(html) == ["gt"]
+      assert input_value(html, "[value][key]") == ["age"]
+      assert input_value(html, "[value][match]") == ["40"]
+    end
+
+    test "a $like filter opens with the includes operator", %{conn: conn, project: project} do
+      {_view, html} = edit_live(conn, project, wrap(%{"data.city" => %{"$like" => "%erl%"}}))
+
+      refute html =~ "can only be edited manually"
+      assert selected_widget(html) == ["includes"]
+      assert input_value(html, "[value][match]") == ["erl"]
+    end
+
+    test "a date comparison filter opens with the before operator", %{conn: conn, project: project} do
+      {_view, html} =
+        edit_live(conn, project, wrap(%{"data.signup" => %{"$lt" => "2024-03-01T00:00:00Z"}}))
+
+      refute html =~ "can only be edited manually"
+      assert selected_widget(html) == ["before"]
+      assert input_value(html, "[value][key]") == ["signup"]
+    end
+  end
+end


### PR DESCRIPTION
Segment filters on custom data (data.*) previously only offered matches, is empty and is not empty in the editor, even though the query layer supported more. This PR exposes the richer set and makes comparisons behave predictably.

**UI (segment editor)**

New operators for custom fields: _starts with, ends with, includes, is greater than, is smaller than, is after date, is before date_.

The value input adapts to the operator (text, number, or the existing date/time/timezone picker), and existing filters are correctly round-tripped back into the editor.

**Query layer (Keila.Contacts.Query)**
$gt/$gte/$lt/$lte on custom data now compare only when the stored value and the filter value are the same JSON type: numbers compare numerically, strings lexicographically, anything else never matches. Previously these fell back to PostgreSQL's JSONB type-rank ordering, which silently matched or excluded contacts based on type rather than value.
Documented the semantics and caveats (e.g. date strings must be ISO 8601 to sort correctly) in the module docs.

**Tests**

Added coverage for the new query semantics and for the editor's form ↔ filter conversions.
No migrations; existing filters keep working.