### PR TITLE
Support ordered sort keys in Contacts API

### DIFF
--- a/lib/keila/contacts/contacts.ex
+++ b/lib/keila/contacts/contacts.ex
@@ -216,7 +216,10 @@ defmodule Keila.Contacts do
 
   This function is idempotent and always returns `:ok`.
   """
-  @spec delete_project_contacts(Project.id(), filter: map(), sort: map()) :: :ok
+  @spec delete_project_contacts(Project.id(),
+          filter: map(),
+          sort: map() | [{String.t(), integer()}]
+        ) :: :ok
   def delete_project_contacts(project_id, opts \\ []) do
     opts = opts |> Keyword.take([:filter]) |> Keyword.put(:sort, false)
 

--- a/lib/keila/contacts/query.ex
+++ b/lib/keila/contacts/query.ex
@@ -38,6 +38,11 @@ defmodule Keila.Contacts.Query do
   - `sort: %{"email" => 1}` will sort results by email in ascending order.
   - `sort: %{"email" => -1}` will sort results by email in descending order.
 
+  When sorting by multiple fields, you can pass a list of `{field, direction}` tuples
+  to preserve a deterministic sort order (Elixir maps do not guarantee key order):
+  - `sort: [{"email", 1}, {"inserted_at", -1}]` will sort by email ascending, then by
+    `inserted_at` descending.
+
   Defaults to sorting by `inserted_at` and `email`.
 
   Sorting can be disabled by passing `sort: false`
@@ -46,7 +51,7 @@ defmodule Keila.Contacts.Query do
   use Keila.Repo
   alias Keila.Contacts.Contact
 
-  @type opts :: {:filter, map()} | {:sort, map()}
+  @type opts :: {:filter, map()} | {:sort, map() | [{String.t(), integer()}]}
 
   @fields ["id", "email", "inserted_at", "first_name", "last_name", "status", "double_opt_in_at"]
   @message_fields [
@@ -279,16 +284,34 @@ defmodule Keila.Contacts.Query do
   defp maybe_sort(query, opts) do
     case Keyword.get(opts, :sort) do
       false -> query
-      opts when is_map(opts) -> sort(query, opts)
+      input when is_map(input) -> sort(query, input)
+      input when is_list(input) -> sort(query, input)
       _ -> sort(query, %{"inserted_at" => 1, "email" => 1})
     end
   end
 
-  defp sort(query, input) do
+  defp sort(query, input) when is_map(input) do
     input
     |> Map.take(@fields)
-    |> Enum.reverse()
-    |> Enum.reduce(query, fn {field, direction}, query ->
+    |> Enum.to_list()
+    |> do_sort(query, reverse?: true)
+  end
+
+  defp sort(query, input) when is_list(input) do
+    input
+    |> Enum.filter(fn {field, _} -> field in @fields end)
+    |> do_sort(query, reverse?: false)
+  end
+
+  defp do_sort(pairs, query, opts) do
+    pairs =
+      if opts[:reverse?] do
+        Enum.reverse(pairs)
+      else
+        pairs
+      end
+
+    Enum.reduce(pairs, query, fn {field, direction}, query ->
       field = String.to_existing_atom(field)
       direction = if direction == -1, do: :desc, else: :asc
 

--- a/lib/keila_web/api/controllers/api_contact_controller.ex
+++ b/lib/keila_web/api/controllers/api_contact_controller.ex
@@ -35,6 +35,16 @@ defmodule KeilaWeb.ApiContactController do
           type: :string,
           "x-validate": KeilaWeb.Api.ContactFilterValidator
         }
+      ],
+      sort: [
+        in: :query,
+        description:
+          "Sort options as JSON string. Accepts a JSON object (`{\"email\": 1}`) or an array of pairs (`[[\"email\", 1], [\"inserted_at\", -1]]`) for deterministic multi-field ordering. `1` = ascending, `-1` = descending.",
+        example: [["email", 1], ["inserted_at", -1]] |> Jason.encode!(),
+        schema: %OpenApiSpex.Schema{
+          type: :string,
+          "x-validate": KeilaWeb.Api.ContactSortValidator
+        }
       ]
     ],
     responses: [
@@ -52,11 +62,13 @@ defmodule KeilaWeb.ApiContactController do
       |> Map.to_list()
 
     filter = Map.get(params, :filter, %{})
+    sort = Map.get(params, :sort)
 
     contacts =
       Contacts.get_project_contacts(project_id(conn),
         paginate: paginate,
-        filter: filter
+        filter: filter,
+        sort: sort
       )
 
     render(conn, "contacts.json", %{contacts: contacts})

--- a/lib/keila_web/api/validators/api_contact_sort_validator.ex
+++ b/lib/keila_web/api/validators/api_contact_sort_validator.ex
@@ -1,0 +1,29 @@
+defmodule KeilaWeb.Api.ContactSortValidator do
+  @moduledoc """
+  OpenApiSpex cast module for casting the `sort` query parameter from a JSON
+  string to an ordered list of `{field, direction}` tuples.
+
+  Accepts either a JSON object (`{"email": 1, "inserted_at": -1}`) or a JSON
+  array of pairs (`[["email", 1], ["inserted_at", -1]]`). The array form
+  preserves key order, which Elixir maps do not guarantee.
+  """
+
+  def cast(ctx = %{value: value}) do
+    with {:ok, json} <- Jason.decode(value) do
+      {:ok, normalize(json)}
+    else
+      _ -> OpenApiSpex.Cast.error(ctx, {:invalid_type, :object})
+    end
+  end
+
+  defp normalize(map) when is_map(map) do
+    Enum.to_list(map)
+  end
+
+  defp normalize(list) when is_list(list) do
+    Enum.map(list, fn
+      [field, direction] -> {field, direction}
+      {field, direction} -> {field, direction}
+    end)
+  end
+end

--- a/test/keila/contacts/contacts_query_test.exs
+++ b/test/keila/contacts/contacts_query_test.exs
@@ -39,6 +39,48 @@ defmodule Keila.ContactsQueryTest do
   end
 
   @tag :contacts_query
+  test "sort contact query with list of tuples preserves order" do
+    c1 =
+      insert!(:contact, %{
+        email: "a@example.com",
+        first_name: "A",
+        inserted_at: ~U[2020-01-01 10:00:00Z]
+      })
+
+    c2 =
+      insert!(:contact, %{
+        email: "a@example.com",
+        first_name: "B",
+        inserted_at: ~U[2020-01-02 10:00:00Z]
+      })
+
+    c3 =
+      insert!(:contact, %{
+        email: "b@example.com",
+        first_name: "C",
+        inserted_at: ~U[2020-01-01 10:00:00Z]
+      })
+
+    # Sort by email asc, then inserted_at desc — list form preserves the specified order
+    assert [c2, c1, c3] ==
+             from(Contact)
+             |> Query.apply(sort: [{"email", 1}, {"inserted_at", -1}])
+             |> Repo.all()
+
+    # Same fields, reversed priority
+    assert [c1, c3, c2] ==
+             from(Contact)
+             |> Query.apply(sort: [{"inserted_at", 1}, {"email", 1}])
+             |> Repo.all()
+
+    # Single-field list sort works the same as map sort
+    assert [c1, c2, c3] ==
+             from(Contact)
+             |> Query.apply(sort: [{"email", 1}, {"inserted_at", 1}])
+             |> Repo.all()
+  end
+
+  @tag :contacts_query
   defp insert_filter_test_contacts!() do
     c1 =
       insert!(:contact, %{

--- a/test/keila_web/api/api_contact_controller_test.exs
+++ b/test/keila_web/api/api_contact_controller_test.exs
@@ -87,6 +87,60 @@ defmodule KeilaWeb.ApiContactControllerTest do
                "errors" => [%{"parameter" => "filter"}]
              } = json_response(conn, 400)
     end
+
+    @tag :api_contact_controller
+    test "supports sorting with JSON object", %{authorized_conn: conn, project: project} do
+      insert!(:contact, project_id: project.id, email: "b@example.com")
+      insert!(:contact, project_id: project.id, email: "a@example.com")
+
+      query = %{"sort" => Jason.encode!(%{"email" => 1})}
+      conn = get(conn, Routes.api_contact_path(conn, :index, query))
+
+      assert %{"data" => [%{"email" => "a@example.com"}, %{"email" => "b@example.com"}]} =
+               json_response(conn, 200)
+    end
+
+    @tag :api_contact_controller
+    test "supports sorting with array of pairs for deterministic order", %{
+      authorized_conn: conn,
+      project: project
+    } do
+      insert!(:contact,
+        project_id: project.id,
+        first_name: "A",
+        email: "b@example.com"
+      )
+
+      insert!(:contact,
+        project_id: project.id,
+        first_name: "A",
+        email: "a@example.com"
+      )
+
+      insert!(:contact,
+        project_id: project.id,
+        first_name: "B",
+        email: "c@example.com"
+      )
+
+      query = %{"sort" => Jason.encode!([["first_name", 1], ["email", 1]])}
+      conn = get(conn, Routes.api_contact_path(conn, :index, query))
+
+      assert %{"data" => [first, second, third]} = json_response(conn, 200)
+      assert first["first_name"] == "A" and first["email"] == "a@example.com"
+      assert second["first_name"] == "A" and second["email"] == "b@example.com"
+      assert third["first_name"] == "B" and third["email"] == "c@example.com"
+    end
+
+    @tag :api_contact_controller
+    test "invalid sort creates error", %{authorized_conn: conn} do
+      query = %{"sort" => "___invalid-sort___"}
+      conn = get(conn, Routes.api_contact_path(conn, :index, query))
+
+      assert %{
+               "errors" => [%{"parameter" => "sort"}]
+             } = json_response(conn, 400)
+    end
   end
 
   describe "POST /api/v1/contacts" do


### PR DESCRIPTION
The `:sort` option of `Keila.Contacts.Query` previously only accepted maps, whose key order is not guaranteed in Elixir. This made multi-field sort order non-deterministic, breaking pagination and reproducibility for API consumers.

The Query module now accepts a list of `{field, direction}` tuples in addition to maps. Lists preserve the caller's sort priority. The Contacts API exposes a new `sort` query parameter (JSON string) that accepts either a JSON object (`{"email": 1}`) or an array of pairs (`[["email", 1], ["inserted_at", -1]]`), cast to an ordered list of tuples via a new `ContactSortValidator`.

The map form still works for backwards compatibility; the array form is the correct way to express multi-field ordering.

Closes #528.