### PR TITLE
Fix update check crashing on v-prefixed release tags

### DIFF
--- a/lib/keila/instance.ex
+++ b/lib/keila/instance.ex
@@ -62,7 +62,16 @@ defmodule Keila.Instance do
       |> Enum.map(fn %{"tag_name" => version, "published_at" => published_at, "body" => changelog} ->
         %{version: version, published_at: published_at, changelog: changelog}
       end)
-      |> Enum.map(&Release.new!/1)
+      |> Enum.flat_map(fn attrs ->
+        case Release.new(attrs) do
+          {:ok, release} ->
+            [release]
+
+          {:error, changeset} ->
+            Logger.info("Unable to parse release: #{inspect(changeset.errors)}")
+            []
+        end
+      end)
       |> Enum.filter(fn %{version: version} ->
         version |> Version.parse!() |> Version.compare(current_version) == :gt
       end)

--- a/lib/keila/instance/schemas/release.ex
+++ b/lib/keila/instance/schemas/release.ex
@@ -10,6 +10,7 @@ defmodule Keila.Instance.Release do
   def changeset(struct \\ %__MODULE__{}, params) do
     struct
     |> cast(params, [:version, :published_at, :changelog])
+    |> update_change(:version, &normalize_version/1)
     |> validate_required([:version, :published_at, :changelog])
     |> validate_change(:version, fn :version, version ->
       case Version.parse(version) do
@@ -22,4 +23,14 @@ defmodule Keila.Instance.Release do
   def new!(params) do
     params |> changeset() |> Ecto.Changeset.apply_action!(:insert)
   end
+
+  def new(params) do
+    params |> changeset() |> Ecto.Changeset.apply_action(:insert)
+  end
+
+  defp normalize_version(version) when is_binary(version) do
+    String.trim_leading(version, "v")
+  end
+
+  defp normalize_version(version), do: version
 end

--- a/test/keila/instance/release_test.exs
+++ b/test/keila/instance/release_test.exs
@@ -1,0 +1,53 @@
+defmodule Keila.Instance.ReleaseTest do
+  use ExUnit.Case, async: true
+
+  alias Keila.Instance.Release
+
+  describe "new!/1" do
+    test "accepts a plain semver version" do
+      release =
+        Release.new!(%{
+          version: "0.30.2",
+          published_at: ~U[2026-04-15 00:00:00Z],
+          changelog: "Bug fixes"
+        })
+
+      assert release.version == "0.30.2"
+    end
+
+    test "strips a leading v prefix from the version" do
+      release =
+        Release.new!(%{
+          version: "v0.30.2",
+          published_at: ~U[2026-04-15 00:00:00Z],
+          changelog: "Bug fixes"
+        })
+
+      assert release.version == "0.30.2"
+    end
+  end
+
+  describe "new/1" do
+    test "returns {:ok, release} for a valid v-prefixed version" do
+      assert {:ok, release} =
+               Release.new(%{
+                 version: "v0.30.2",
+                 published_at: ~U[2026-04-15 00:00:00Z],
+                 changelog: "Bug fixes"
+               })
+
+      assert release.version == "0.30.2"
+    end
+
+    test "returns {:error, changeset} for an invalid version" do
+      assert {:error, changeset} =
+               Release.new(%{
+                 version: "not-a-version",
+                 published_at: ~U[2026-04-15 00:00:00Z],
+                 changelog: "Bug fixes"
+               })
+
+      assert Keyword.has_key?(changeset.errors, :version)
+    end
+  end
+end


### PR DESCRIPTION
Since v0.19.1, Keila's git tags use a `v` prefix (`v0.30.2` instead of `0.30.2`). Elixir's `Version.parse/1` requires strict semver and rejects the `v` prefix, so `Release.changeset` marked every current release as invalid and `Release.new!/1` raised `Ecto.InvalidChangesetError`. The exception was uncaught in `fetch_updates/0`, silently breaking the daily update check on every deployed instance — the admin UI keeps reporting "up to date" even when it isn't.

Strips a leading `v` from the version string in `Release.changeset` before validation, and switches `fetch_updates/0` to the non-raising `Release.new/1` so a single malformed release is logged and skipped instead of crashing the whole job.

Closes #546.