### PR TITLE
Implement Liquid template cache

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -95,7 +95,7 @@ config :phoenix, :json_library, Jason
 config :keila, Oban,
   queues: [
     mailer: 100,
-    campaign_renderer: 3,
+    campaign_renderer: 2,
     campaign_scheduler: 1,
     system: 1
   ],

--- a/lib/keila/application.ex
+++ b/lib/keila/application.ex
@@ -23,6 +23,8 @@ defmodule Keila.Application do
         {Oban, oban_config()},
         # Keila Task Supervisor
         {Task.Supervisor, name: Keila.TaskSupervisor},
+        # Liquid cache,
+        Keila.Mailings.Renderer.LiquidCache,
         # Keila Hashid Config cache
         %{
           id: Keila.Id.Cache,

--- a/lib/keila/application.ex
+++ b/lib/keila/application.ex
@@ -19,12 +19,12 @@ defmodule Keila.Application do
         {Phoenix.PubSub, name: Keila.PubSub},
         # Start the Endpoint (http/https)
         KeilaWeb.Endpoint,
+        # Liquid cache,
+        Keila.Mailings.Renderer.LiquidCache,
         # Start Oban
         {Oban, oban_config()},
         # Keila Task Supervisor
         {Task.Supervisor, name: Keila.TaskSupervisor},
-        # Liquid cache,
-        Keila.Mailings.Renderer.LiquidCache,
         # Keila Hashid Config cache
         %{
           id: Keila.Id.Cache,

--- a/lib/keila/mailings/campaign_render_rescue_worker.ex
+++ b/lib/keila/mailings/campaign_render_rescue_worker.ex
@@ -19,12 +19,12 @@ defmodule Keila.Mailings.CampaignRenderRescueWorker do
       Keila.Mailings.CampaignRenderWorker.new(%{campaign_id: campaign_id})
       |> Oban.insert()
       |> case do
-        {:ok, _} ->
+        {:ok, %Oban.Job{conflict?: false}} ->
           Logger.warning(
             "CampaignRenderRescueWorker: Enqueued campaign render worker for campaign_id: #{campaign_id}"
           )
 
-        _ ->
+        _other ->
           :ok
       end
     end)

--- a/lib/keila/mailings/campaign_render_worker.ex
+++ b/lib/keila/mailings/campaign_render_worker.ex
@@ -25,7 +25,7 @@ defmodule Keila.Mailings.CampaignRenderWorker do
   alias Keila.Contacts
   alias Keila.Contacts.Contact
 
-  @batch_size 500
+  @batch_size 50
   @render_timeout 5_000
   @max_attempts 5
 

--- a/lib/keila/mailings/campaign_render_worker.ex
+++ b/lib/keila/mailings/campaign_render_worker.ex
@@ -14,7 +14,7 @@ defmodule Keila.Mailings.CampaignRenderWorker do
     queue: :campaign_renderer,
     unique: [
       period: :infinity,
-      states: [:available, :scheduled, :retryable],
+      states: [:available, :scheduled, :retryable, :executing],
       keys: [:campaign_id]
     ]
 
@@ -54,7 +54,7 @@ defmodule Keila.Mailings.CampaignRenderWorker do
     |> tap(&update_messages_for_retry/1)
     |> tap(fn results ->
       if length(results) == @batch_size or Enum.any?(results, &retryable?/1) do
-        Oban.insert!(new(%{"campaign_id" => campaign.id}))
+        Oban.insert!(new(%{"campaign_id" => campaign.id}, unique: false))
       end
     end)
 

--- a/lib/keila/mailings/renderer/body_renderer/html.ex
+++ b/lib/keila/mailings/renderer/body_renderer/html.ex
@@ -4,7 +4,6 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Html do
   """
   @behaviour Keila.Mailings.Renderer.BodyRenderer
 
-  use KeilaWeb.Gettext
   alias Keila.Mailings.Renderer
   alias Keila.Mailings.Renderer.Input
   import Keila.Mailings.Renderer.LiquidRenderer
@@ -30,8 +29,9 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Html do
     end)
   end
 
-  defp input_hash(%Input{html_body: html_body, template: template, html_content: html_content}) do
-    :crypto.hash(:sha256, :erlang.term_to_binary({html_body, template, html_content}))
+  defp input_hash(%Input{html_body: html_body, html_content: html_content, template: template}) do
+    template_fields = if template, do: Map.take(template, [:id, :updated_at, :name, :html_body])
+    :crypto.hash(:sha256, :erlang.term_to_binary({html_body, html_content, template_fields}))
   end
 
   defp merge_html(%Input{html_body: html_body, template: template, html_content: html_content}) do

--- a/lib/keila/mailings/renderer/body_renderer/html.ex
+++ b/lib/keila/mailings/renderer/body_renderer/html.ex
@@ -7,23 +7,34 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Html do
   use KeilaWeb.Gettext
   alias Keila.Mailings.Renderer
   alias Keila.Mailings.Renderer.Input
+  import Keila.Mailings.Renderer.LiquidRenderer
 
   @impl true
   def render(output, %Input{} = input, assigns) do
-    case render_liquid(merged_html(input), assigns) do
-      {:ok, rendered_html} ->
-        %{
-          output
-          | html_body: rendered_html,
-            text_body: Renderer.html_to_text(rendered_html)
-        }
-
+    with {:ok, liquid_template} <- liquid_template(input),
+         {:ok, html_body} <- render_liquid(liquid_template, assigns) do
+      %{output | html_body: html_body, text_body: Renderer.html_to_text(html_body)}
+    else
       {:error, reason} ->
         %{output | text_body: reason, errors: [reason | output.errors]}
     end
   end
 
-  defp merged_html(%Input{html_body: html_body, template: template, html_content: html_content}) do
+  defp liquid_template(input) do
+    hash = input_hash(input)
+
+    Keila.Mailings.Renderer.LiquidCache.get(hash, fn ->
+      input
+      |> merge_html()
+      |> parse_liquid()
+    end)
+  end
+
+  defp input_hash(%Input{html_body: html_body, template: template, html_content: html_content}) do
+    :crypto.hash(:sha256, :erlang.term_to_binary({html_body, template, html_content}))
+  end
+
+  defp merge_html(%Input{html_body: html_body, template: template, html_content: html_content}) do
     body =
       case {html_body, template} do
         {html, _} when is_binary(html) and html != "" -> html
@@ -32,15 +43,5 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Html do
       end
 
     Keila.Templates.merge_content_slots(body, html_content || %{}, mode: :html)
-  end
-
-  defp render_liquid(input, assigns) do
-    case Keila.Mailings.Renderer.LiquidRenderer.render_liquid(input, assigns) do
-      {:ok, output} ->
-        {:ok, output}
-
-      {:error, reason} ->
-        {:error, gettext("Error compiling Liquid: %{reason}", reason: reason)}
-    end
   end
 end

--- a/lib/keila/mailings/renderer/body_renderer/mjml.ex
+++ b/lib/keila/mailings/renderer/body_renderer/mjml.ex
@@ -21,7 +21,7 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
     end
   end
 
-  def liquid_template(input) do
+  defp liquid_template(input) do
     hash = input_hash(input)
 
     Keila.Mailings.Renderer.LiquidCache.get(hash, fn ->

--- a/lib/keila/mailings/renderer/body_renderer/mjml.ex
+++ b/lib/keila/mailings/renderer/body_renderer/mjml.ex
@@ -4,7 +4,6 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
   """
   @behaviour Keila.Mailings.Renderer.BodyRenderer
 
-  use KeilaWeb.Gettext
   alias Keila.Mailings.Renderer
   alias Keila.Mailings.Renderer.Input
   import Keila.Mailings.Renderer.LiquidRenderer
@@ -32,8 +31,9 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
     end)
   end
 
-  defp input_hash(%Input{mjml_body: mjml_body, template: template, mjml_content: mjml_content}) do
-    :crypto.hash(:sha256, :erlang.term_to_binary({mjml_body, template, mjml_content}))
+  defp input_hash(%Input{mjml_body: mjml_body, mjml_content: mjml_content, template: template}) do
+    template_fields = if template, do: Map.take(template, [:id, :updated_at, :name, :mjml_body])
+    :crypto.hash(:sha256, :erlang.term_to_binary({mjml_body, mjml_content, template_fields}))
   end
 
   defp merge_mjml(%Input{mjml_body: mjml_body, template: template, mjml_content: mjml_content}) do

--- a/lib/keila/mailings/renderer/body_renderer/mjml.ex
+++ b/lib/keila/mailings/renderer/body_renderer/mjml.ex
@@ -4,6 +4,7 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
   """
   @behaviour Keila.Mailings.Renderer.BodyRenderer
 
+  use KeilaWeb.Gettext
   alias Keila.Mailings.Renderer
   alias Keila.Mailings.Renderer.Input
   import Keila.Mailings.Renderer.LiquidRenderer

--- a/lib/keila/mailings/renderer/body_renderer/mjml.ex
+++ b/lib/keila/mailings/renderer/body_renderer/mjml.ex
@@ -7,25 +7,33 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
   use KeilaWeb.Gettext
   alias Keila.Mailings.Renderer
   alias Keila.Mailings.Renderer.Input
+  import Keila.Mailings.Renderer.LiquidRenderer
 
   @impl true
   def render(output, %Input{} = input, assigns) do
-    mjml =
-      input
-      |> merge_mjml()
-      |> remove_code_blocks()
-
-    with {:ok, mjml} <- render_liquid(mjml, assigns),
+    with {:ok, liquid_template} <- liquid_template(input),
+         {:ok, mjml} <- render_liquid(liquid_template, assigns),
          {:ok, html_body} <- render_mjml(mjml) do
-      %{
-        output
-        | html_body: html_body,
-          text_body: Renderer.html_to_text(html_body)
-      }
+      %{output | html_body: html_body, text_body: Renderer.html_to_text(html_body)}
     else
       {:error, reason} ->
         %{output | text_body: reason, errors: [reason | output.errors]}
     end
+  end
+
+  def liquid_template(input) do
+    hash = input_hash(input)
+
+    Keila.Mailings.Renderer.LiquidCache.get(hash, fn ->
+      input
+      |> merge_mjml()
+      |> remove_code_blocks()
+      |> Keila.Mailings.Renderer.LiquidRenderer.parse_liquid()
+    end)
+  end
+
+  defp input_hash(%Input{mjml_body: mjml_body, template: template, mjml_content: mjml_content}) do
+    :crypto.hash(:sha256, :erlang.term_to_binary({mjml_body, template, mjml_content}))
   end
 
   defp merge_mjml(%Input{mjml_body: mjml_body, template: template, mjml_content: mjml_content}) do
@@ -60,15 +68,5 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Mjml do
   # https://github.com/jdrouet/mrml/issues/654
   defp normalize_newlines(mjml) do
     String.replace(mjml, ~r/\r\n?/, "\n")
-  end
-
-  defp render_liquid(mjml, assigns) do
-    case Keila.Mailings.Renderer.LiquidRenderer.render_liquid(mjml, assigns) do
-      {:ok, rendered_mjml} ->
-        {:ok, rendered_mjml}
-
-      {:error, reason} ->
-        {:error, gettext("Error compiling Liquid: %{reason}", reason: reason)}
-    end
   end
 end

--- a/lib/keila/mailings/renderer/body_renderer/text.ex
+++ b/lib/keila/mailings/renderer/body_renderer/text.ex
@@ -30,11 +30,16 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Text do
   end
 
   defp input_hash(
-         %Input{text_body: text_body, template: template, text_content: text_content},
+         %Input{text_body: text_body, text_content: text_content, template: template},
          assigns
        ) do
     signature = assigns["signature"]
-    :crypto.hash(:sha256, :erlang.term_to_binary({text_body, template, text_content, signature}))
+    template_fields = if template, do: Map.take(template, [:id, :updated_at, :name, :text_body])
+
+    :crypto.hash(
+      :sha256,
+      :erlang.term_to_binary({text_body, text_content, signature, template_fields})
+    )
   end
 
   # Without a template, append the signature directly to the body.

--- a/lib/keila/mailings/renderer/body_renderer/text.ex
+++ b/lib/keila/mailings/renderer/body_renderer/text.ex
@@ -10,19 +10,37 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Text do
 
   @impl true
   def render(output, %Input{} = input, assigns) do
-    case render_liquid(body(input, assigns), assigns) do
-      {:ok, text_body} ->
-        %{output | text_body: text_body}
-
+    with {:ok, liquid_template} <- liquid_template(input, assigns),
+         {:ok, text_body} <- render_liquid(liquid_template, assigns) do
+      %{output | text_body: text_body}
+    else
       {:error, error} ->
         %{output | text_body: error, errors: [error | output.errors]}
     end
   end
 
+  defp liquid_template(input, assigns) do
+    hash = input_hash(input, assigns)
+
+    Keila.Mailings.Renderer.LiquidCache.get(hash, fn ->
+      input
+      |> merge_text(assigns)
+      |> parse_liquid()
+    end)
+  end
+
+  defp input_hash(
+         %Input{text_body: text_body, template: template, text_content: text_content},
+         assigns
+       ) do
+    signature = assigns["signature"]
+    :crypto.hash(:sha256, :erlang.term_to_binary({text_body, template, text_content, signature}))
+  end
+
   # Without a template, append the signature directly to the body.
   # This is the legacy behavior from before there were text templates.
   # and might be deprecated in the future
-  defp body(%Input{template: nil} = input, assigns) do
+  defp merge_text(%Input{template: nil} = input, assigns) do
     signature = assigns["signature"] || HybridTemplate.text_signature()
 
     if signature == "" do
@@ -33,7 +51,7 @@ defmodule Keila.Mailings.Renderer.BodyRenderer.Text do
   end
 
   # With a template, merge the body into the template's text content slots.
-  defp body(%Input{} = input, _assigns) do
+  defp merge_text(%Input{} = input, _assigns) do
     text_body =
       case {input.text_body, input.template} do
         {body, _} when is_binary(body) and body != "" -> body

--- a/lib/keila/mailings/renderer/liquid_cache.ex
+++ b/lib/keila/mailings/renderer/liquid_cache.ex
@@ -1,0 +1,89 @@
+defmodule Keila.Mailings.Renderer.LiquidCache do
+  @moduledoc """
+  Parsing Liquid templates with Solid is relatively resource intensive.
+  In order to preserve system resources when sending large campaigns or
+  campaigns with large templates, BodyRenderer modules may use this module
+  to cache parsed Liquid templates.
+  """
+
+  use GenServer
+
+  @ttl :timer.minutes(10)
+  @max_entries 500
+  @evict_interval :timer.seconds(30)
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @spec get(String.t(), (-> term())) :: term()
+  def get(sha256, fun) do
+    cached_template = GenServer.call(__MODULE__, {:get, sha256})
+
+    if cached_template do
+      cached_template
+    else
+      fun.() |> tap(&GenServer.cast(__MODULE__, {:set, sha256, &1}))
+    end
+  end
+
+  @impl true
+  def init(_) do
+    table = :ets.new(:liquid_cache, [:set, :protected, {:read_concurrency, true}])
+    schedule_evict()
+
+    {:ok, table}
+  end
+
+  @impl true
+  def handle_call({:get, sha256}, _, table) do
+    case :ets.lookup(table, sha256) do
+      [{sha256, template, _}] ->
+        :ets.update_element(table, sha256, {3, now()})
+        {:reply, template, table}
+
+      [] ->
+        {:reply, nil, table}
+    end
+  end
+
+  @impl true
+  def handle_cast({:set, sha256, template}, table) do
+    :ets.insert(table, {sha256, template, now()})
+
+    {:noreply, table}
+  end
+
+  @impl true
+  def handle_info(:evict, table) do
+    schedule_evict()
+
+    cutoff = now() - @ttl
+
+    {entries, expired_entries} =
+      table
+      |> :ets.tab2list()
+      |> Enum.split_with(fn {_, _, timestamp} -> timestamp >= cutoff end)
+
+    Enum.each(expired_entries, fn {sha256, _, _} -> :ets.delete(table, sha256) end)
+
+    count = length(entries)
+
+    if count > @max_entries do
+      entries
+      |> Enum.sort_by(fn {_, _, timestamp} -> timestamp end, :desc)
+      |> Enum.drop(@max_entries)
+      |> Enum.each(fn {sha256, _, _} -> :ets.delete(table, sha256) end)
+    end
+
+    {:noreply, table}
+  end
+
+  defp now() do
+    System.monotonic_time(:millisecond)
+  end
+
+  defp schedule_evict() do
+    Process.send_after(self(), :evict, @evict_interval)
+  end
+end

--- a/lib/keila/mailings/renderer/liquid_cache.ex
+++ b/lib/keila/mailings/renderer/liquid_cache.ex
@@ -26,6 +26,8 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
     else
       fun.() |> tap(&write_to_cache(sha256, &1))
     end
+  rescue
+    ArgumentError -> fun.()
   end
 
   defp get_from_cache(sha256) do
@@ -59,6 +61,9 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
     {:ok, table}
   end
 
+  # :ets.fun2ms(fn {sha256, _, timestamp} -> {sha256, timestamp} end)
+  @timestamp_ms [{{:"$1", :_, :"$2"}, [], [{{:"$1", :"$2"}}]}]
+
   @impl true
   def handle_info(:evict, table) do
     schedule_evict()
@@ -67,18 +72,18 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
 
     {entries, expired_entries} =
       table
-      |> :ets.tab2list()
-      |> Enum.split_with(fn {_, _, timestamp} -> timestamp >= cutoff end)
+      |> :ets.select(@timestamp_ms)
+      |> Enum.split_with(fn {_, timestamp} -> timestamp >= cutoff end)
 
-    Enum.each(expired_entries, fn {sha256, _, _} -> :ets.delete(table, sha256) end)
+    Enum.each(expired_entries, fn {sha256, _} -> :ets.delete(table, sha256) end)
 
     count = length(entries)
 
     if count > @max_entries do
       entries
-      |> Enum.sort_by(fn {_, _, timestamp} -> timestamp end, :desc)
+      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, :desc)
       |> Enum.drop(@max_entries)
-      |> Enum.each(fn {sha256, _, _} -> :ets.delete(table, sha256) end)
+      |> Enum.each(fn {sha256, _} -> :ets.delete(table, sha256) end)
     end
 
     {:noreply, table}

--- a/lib/keila/mailings/renderer/liquid_cache.ex
+++ b/lib/keila/mailings/renderer/liquid_cache.ex
@@ -8,6 +8,7 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
 
   use GenServer
 
+  @table __MODULE__
   @ttl :timer.minutes(10)
   @max_entries 500
   @evict_interval :timer.seconds(30)
@@ -18,40 +19,44 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
 
   @spec get(String.t(), (-> term())) :: term()
   def get(sha256, fun) do
-    cached_template = GenServer.call(__MODULE__, {:get, sha256})
+    cached_template = get_from_cache(sha256)
 
     if cached_template do
       cached_template
     else
-      fun.() |> tap(&GenServer.cast(__MODULE__, {:set, sha256, &1}))
+      fun.() |> tap(&write_to_cache(sha256, &1))
     end
+  end
+
+  defp get_from_cache(sha256) do
+    case :ets.lookup(@table, sha256) do
+      [{^sha256, template, _}] ->
+        :ets.update_element(@table, sha256, {3, now()})
+        template
+
+      [] ->
+        nil
+    end
+  end
+
+  defp write_to_cache(sha256, template) do
+    :ets.insert(@table, {sha256, template, now()})
   end
 
   @impl true
   def init(_) do
-    table = :ets.new(:liquid_cache, [:set, :protected, {:read_concurrency, true}])
+    table =
+      :ets.new(@table, [
+        :set,
+        :public,
+        :named_table,
+        {:read_concurrency, true},
+        {:write_concurrency, true}
+      ])
+
     schedule_evict()
 
     {:ok, table}
-  end
-
-  @impl true
-  def handle_call({:get, sha256}, _, table) do
-    case :ets.lookup(table, sha256) do
-      [{sha256, template, _}] ->
-        :ets.update_element(table, sha256, {3, now()})
-        {:reply, template, table}
-
-      [] ->
-        {:reply, nil, table}
-    end
-  end
-
-  @impl true
-  def handle_cast({:set, sha256, template}, table) do
-    :ets.insert(table, {sha256, template, now()})
-
-    {:noreply, table}
   end
 
   @impl true

--- a/lib/keila/mailings/renderer/liquid_cache.ex
+++ b/lib/keila/mailings/renderer/liquid_cache.ex
@@ -17,6 +17,10 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
+  @doc """
+  Fetches an entry by the `sha256` key or executes and persists
+  the result of `fun/0` if the key is not present.
+  """
   @spec get(binary(), (-> term())) :: term()
   def get(sha256, fun) do
     cached_template = get_from_cache(sha256)
@@ -29,6 +33,12 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
   rescue
     ArgumentError -> fun.()
   end
+
+  @spec ttl() :: pos_integer()
+  def ttl(), do: @ttl
+
+  @spec max_entries() :: pos_integer()
+  def max_entries(), do: @max_entries
 
   defp get_from_cache(sha256) do
     case :ets.lookup(@table, sha256) do

--- a/lib/keila/mailings/renderer/liquid_cache.ex
+++ b/lib/keila/mailings/renderer/liquid_cache.ex
@@ -17,7 +17,7 @@ defmodule Keila.Mailings.Renderer.LiquidCache do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
-  @spec get(String.t(), (-> term())) :: term()
+  @spec get(binary(), (-> term())) :: term()
   def get(sha256, fun) do
     cached_template = get_from_cache(sha256)
 

--- a/lib/keila/mailings/renderer/liquid_renderer.ex
+++ b/lib/keila/mailings/renderer/liquid_renderer.ex
@@ -1,10 +1,25 @@
 defmodule Keila.Mailings.Renderer.LiquidRenderer do
   @moduledoc """
-  Module to safely render Liquid templates from a string or a pre-parsed by `Solid.Template`.
+  Module to safely parse and render Liquid templates.
   """
 
   @doc """
-  Safely renders a liquid template to a string.
+  Safely remders Liquid string to a Solid template struct.
+  """
+  @spec parse_liquid(String.t()) :: {:ok, Solid.Template.t()} | {:error, String.t()}
+  def parse_liquid(input) do
+    try do
+      case Solid.parse(input) do
+        {:ok, template} -> {:ok, template}
+        {:error, error = %Solid.TemplateError{}} -> {:error, errors_to_string(error.errors)}
+      end
+    rescue
+      _e -> {:error, "Unexpected parsing error"}
+    end
+  end
+
+  @doc """
+  Safely renders a Liquid template to a string. Accepts strings and `Solid.Template`.
 
   Solid can sometimes raise exceptions when rendering invalid templates. This
   function catches these exceptions and transforms them into an error tuple.
@@ -14,13 +29,8 @@ defmodule Keila.Mailings.Renderer.LiquidRenderer do
   def render_liquid(input, assigns, opts \\ [])
 
   def render_liquid(input, assigns, opts) when is_binary(input) do
-    try do
-      case Solid.parse(input) do
-        {:ok, template} -> render_liquid(template, assigns, opts)
-        {:error, error = %Solid.TemplateError{}} -> {:error, errors_to_string(error.errors)}
-      end
-    rescue
-      _e -> {:error, "Unexpected parsing error"}
+    with {:ok, liquid_template} <- parse_liquid(input) do
+      render_liquid(liquid_template, assigns, opts)
     end
   end
 

--- a/lib/keila/mailings/renderer/liquid_renderer.ex
+++ b/lib/keila/mailings/renderer/liquid_renderer.ex
@@ -4,7 +4,7 @@ defmodule Keila.Mailings.Renderer.LiquidRenderer do
   """
 
   @doc """
-  Safely remders Liquid string to a Solid template struct.
+  Safely renders Liquid string to a Solid template struct.
   """
   @spec parse_liquid(String.t()) :: {:ok, Solid.Template.t()} | {:error, String.t()}
   def parse_liquid(input) do

--- a/test/keila/mailings/renderer/liquid_cache_test.exs
+++ b/test/keila/mailings/renderer/liquid_cache_test.exs
@@ -1,0 +1,78 @@
+defmodule Keila.Mailings.Renderer.LiquidCacheTest do
+  use ExUnit.Case, async: false
+  alias Keila.Mailings.Renderer.LiquidCache
+
+  setup do
+    :ets.delete_all_objects(LiquidCache)
+    :ok
+  end
+
+  test "get/2 runs the fun on a miss, caches the result, and serves hits without re-running" do
+    sha256 = sha256()
+    self = self()
+
+    assert {:ok, :parsed} = LiquidCache.get(sha256, fn -> {:ok, :parsed} end)
+    assert [{^sha256, {:ok, :parsed}, _}] = :ets.lookup(LiquidCache, sha256)
+
+    assert {:ok, :parsed} = LiquidCache.get(sha256, fn -> send(self, :again) && {:ok, :other} end)
+    refute_receive :again
+  end
+
+  test "get/2 refreshes cache entry timestamp" do
+    sha256 = sha256()
+    inserted_at = now() - div(LiquidCache.ttl(), 2)
+    :ets.insert(LiquidCache, {sha256, :cached, inserted_at})
+
+    assert :cached = LiquidCache.get(sha256, fn -> nil end)
+
+    [{^sha256, _value, retrieved_at}] = :ets.lookup(LiquidCache, sha256)
+    assert retrieved_at > inserted_at
+  end
+
+  test "get/2 returns function result even when LiquidCache process is down" do
+    :ok = Supervisor.terminate_child(Keila.Supervisor, LiquidCache)
+    assert :result = LiquidCache.get(sha256(), fn -> :result end)
+  after
+    {:ok, _pid} = Supervisor.restart_child(Keila.Supervisor, LiquidCache)
+  end
+
+  test "evict removes entries older than the TTL" do
+    recent = sha256()
+    stale = sha256()
+    :ets.insert(LiquidCache, {recent, :recent, now()})
+    :ets.insert(LiquidCache, {stale, :stale, now() - LiquidCache.ttl() - 1})
+
+    evict()
+
+    assert [{^recent, _, _}] = :ets.lookup(LiquidCache, recent)
+    assert [] = :ets.lookup(LiquidCache, stale)
+  end
+
+  test "evict enforces entries limit and drops old entries" do
+    now = now()
+
+    [oldest | rest] =
+      for i <- 0..LiquidCache.max_entries() do
+        sha256 = sha256()
+        :ets.insert(LiquidCache, {sha256, i, now + i})
+        sha256
+      end
+
+    evict()
+
+    assert :ets.info(LiquidCache, :size) == LiquidCache.max_entries()
+    assert [] = :ets.lookup(LiquidCache, oldest)
+    assert Enum.all?(rest, fn sha256 -> :ets.lookup(LiquidCache, sha256) != [] end)
+  end
+
+  defp sha256(), do: :crypto.hash(:sha256, "test-#{System.unique_integer([:positive])}")
+
+  defp now(), do: System.monotonic_time(:millisecond)
+
+  defp evict() do
+    send(Process.whereis(LiquidCache), :evict)
+
+    # Ensure LiquidCache has processed its message queue
+    :sys.get_state(LiquidCache)
+  end
+end


### PR DESCRIPTION
This PR adds a Cache layer for Liquid/Solid templates. This is useful because parsing Liquid only needs to happen once per campaign sendout and is surprisingly resource-intensive, especially on larger templates.

The PR also modifies the CampaignRenderer and CampaignRenderRescue workers to reduce batch size and to make sure there is only one worker per campaign.